### PR TITLE
core, oe: Fix variable name

### DIFF
--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -8,4 +8,4 @@ SRC_URI_append = " \
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and
 # does not intent to address it in OpenSSH
 # https://security-tracker.debian.org/tracker/CVE-2023-51767
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-51767"
+CVE_CHECK_WHITELIST += "CVE-2023-51767"

--- a/meta-core/recipes-exended/libarchive/libarchive_3.4.2.bbappend
+++ b/meta-core/recipes-exended/libarchive/libarchive_3.4.2.bbappend
@@ -8,17 +8,17 @@ SRC_URI_append = " \
 # cpe-incorrect:
 # The out-of-bounds access in question was introduced after 3.7.3 and fixed in
 # 3.7.4, so it does not apply to our version and we can safely ignore it.
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-37407 CVE-2024-26256 CVE-2024-48957 CVE-2024-48958"
+CVE_CHECK_WHITELIST += "CVE-2024-37407 CVE-2024-26256 CVE-2024-48957 CVE-2024-48958"
 
 # cpe-incorrect:
 # The null pointer dereference vulnerability was introduced after 3.7.5 and was
 # fixed by commit 565b5aea, so it does not apply to our version and we can mark
 # 3.4.2 as fixed.
 # https://github.com/libarchive/libarchive/issues/2559
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-48615"
+CVE_CHECK_WHITELIST += "CVE-2024-48615"
 
 # cpe-incorrect:
 # The null pointer dereference vulnerability was introduced in 3.7.0 (c157e4c)
 # when the bsdunzip command was ported to libarchive. This version is unaffected
 # so this CVE can be dismissed.
-CVE_CHECK_CVE_WHITELIST += "CVE-2025-1632"
+CVE_CHECK_WHITELIST += "CVE-2025-1632"

--- a/meta-core/recipes-multimedia/gstreamer/gstreamer1.0_1.16.%.bbappend
+++ b/meta-core/recipes-multimedia/gstreamer/gstreamer1.0_1.16.%.bbappend
@@ -7,148 +7,148 @@ SRC_URI += " \
 # fixed-version
 # Patched in gstreamer1.0-plugins-base_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2024-47600
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47600"
+CVE_CHECK_WHITELIST += "CVE-2024-47600"
 
 # fixed-version
 # Patched in gstreamer1.0-plugins-bad_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2023-40474"
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-40474"
+CVE_CHECK_WHITELIST += "CVE-2023-40474"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-bad_1.16.%.bbappend
 # with CVE-2023-40474.patch
 # https://security-tracker.debian.org/tracker/CVE-2023-40475"
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-40475"
+CVE_CHECK_WHITELIST += "CVE-2023-40475"
 
 # fixed-version:
 # 1.16.3 gst-plugins-bad not-affected (AV1 parser introduced in 1.17.1)
 # https://security-tracker.debian.org/tracker/CVE-2024-0444"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-0444"
+CVE_CHECK_WHITELIST += "CVE-2024-0444"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-bad_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2023-40476"
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-40476"
+CVE_CHECK_WHITELIST += "CVE-2023-40476"
 
 # fixed-version:
 # 1.16.3 gst-plugins-bad not-affected (AV1 parser introduced in 1.17.1)
 # https://security-tracker.debian.org/tracker/CVE-2023-44429"
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-44429"
+CVE_CHECK_WHITELIST += "CVE-2023-44429"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-bad_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2023-44446"
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-44446"
+CVE_CHECK_WHITELIST += "CVE-2023-44446"
 
 # fixed-version:
 # 1.16.3 gst-plugins-bad not-affected (AV1 parser introduced after 1.18.4)
 # https://security-tracker.debian.org/tracker/CVE-2023-50186"
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-50186"
+CVE_CHECK_WHITELIST += "CVE-2023-50186"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-bad_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2023-37329"
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-37329"
+CVE_CHECK_WHITELIST += "CVE-2023-37329"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # Patched in gstreamer1.0-plugins-base_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2023-37327"
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-37327"
+CVE_CHECK_WHITELIST += "CVE-2023-37327"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-base_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2023-37328"
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-37328"
+CVE_CHECK_WHITELIST += "CVE-2023-37328"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2024-47613"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47613"
+CVE_CHECK_WHITELIST += "CVE-2024-47613"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-base_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2024-47615"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47615"
+CVE_CHECK_WHITELIST += "CVE-2024-47615"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # with patch CVE-2024-47537.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47537"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47537"
+CVE_CHECK_WHITELIST += "CVE-2024-47537"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # with patch CVE-2024-47537.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47539"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47539"
+CVE_CHECK_WHITELIST += "CVE-2024-47539"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # with patch CVE-2024-47537.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47597"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47597"
+CVE_CHECK_WHITELIST += "CVE-2024-47597"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # with patch CVE-2024-47537.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47598"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47598"
+CVE_CHECK_WHITELIST += "CVE-2024-47598"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-base_1.16.%.bbappend
 # with patch CVE-2024-47607.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47607"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47607"
+CVE_CHECK_WHITELIST += "CVE-2024-47607"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # with patch CVE-2024-47538.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47538"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47538"
+CVE_CHECK_WHITELIST += "CVE-2024-47538"
 
 # fixed-version:
 # Patched in gstreamer1.0_1.16.%.bbappend
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2024-47606"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47606"
+CVE_CHECK_WHITELIST += "CVE-2024-47606"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-base_1.16.%.bbappend
 # with patch CVE-2024-47775.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47775"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47775"
+CVE_CHECK_WHITELIST += "CVE-2024-47775"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-base_1.16.%.bbappend
 # with patch CVE-2024-47775.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47776"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47776"
+CVE_CHECK_WHITELIST += "CVE-2024-47776"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # with patch CVE-2024-47775.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47777"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47777"
+CVE_CHECK_WHITELIST += "CVE-2024-47777"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # with patch CVE-2024-47775.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47778"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47778"
+CVE_CHECK_WHITELIST += "CVE-2024-47778"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2024-47774"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47774"
+CVE_CHECK_WHITELIST += "CVE-2024-47774"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # https://security-tracker.debian.org/tracker/CVE-2024-47540"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47540"
+CVE_CHECK_WHITELIST += "CVE-2024-47540"
 
 # fixed-version:
 # Patched in gstreamer1.0-plugins-good_1.16.%.bbappend
 # with patch CVE-2024-47540.patch
 # https://security-tracker.debian.org/tracker/CVE-2024-47834"
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-47834"
+CVE_CHECK_WHITELIST += "CVE-2024-47834"

--- a/meta-core/recipes-support/curl/curl_7.69.1.bbappend
+++ b/meta-core/recipes-support/curl/curl_7.69.1.bbappend
@@ -6,10 +6,10 @@ SRC_URI_append = " \
 
 # The use-after-free in question doesn't appear until 7.81.0, therefore we can
 # safely ignore it for this version.
-CVE_CHECK_CVE_WHITELIST += "CVE-2023-28319"
+CVE_CHECK_WHITELIST += "CVE-2023-28319"
 
 # not-applicable-platform: CURLOPT_SSL_VERIFYPEER was disabled on google cloud services causing a potential man in the middle attack
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-32928"
+CVE_CHECK_WHITELIST += "CVE-2024-32928"
 
 # not-applicable-config: gzip decompression of content-encoded HTTP responses with the `CURLOPT_ACCEPT_ENCODING` option, using zlib 1.2.0.3 or older
-CVE_CHECK_CVE_WHITELIST += "CVE-2025-0725"
+CVE_CHECK_WHITELIST += "CVE-2025-0725"

--- a/meta-oe/recipes-devtools/jq/jq_1.6.bbappend
+++ b/meta-oe/recipes-devtools/jq/jq_1.6.bbappend
@@ -7,4 +7,4 @@ SRC_URI_append = " \
 
 # fixed-version: Does not affect jq 1.6.
 # Introduced by: https://github.com/jqlang/jq/commit/cf4b48c7ba30cb30e116b523cff036ea481459f6 (jq-1.7rc1)
-CVE_CHECK_CVE_WHITELIST += "CVE-2024-53427"
+CVE_CHECK_WHITELIST += "CVE-2024-53427"


### PR DESCRIPTION
CVE_CHECK_CVE_WHITELIST was the variable name for Yocto < 3.0. It was mistakenly used in this layer. CVE_CHECK_WHITELIST is the correct variable name for Dunfell (3.1) and all incorrect variable names have been updated.