### PR TITLE
ci: Fix changed files

### DIFF
--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -30,6 +30,9 @@ on:  # yamllint disable-line rule:truthy
         required: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   bitbake:
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -75,19 +75,20 @@ jobs:
 
       - name: Get changed files
         id: changed-files
+        if: ${{ inputs.only-build-modified }}
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62  # v47
 
       - name: Get build targets
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         id: targets
         run: |
-          if [ "${{ inputs.only-build-modified }}" = "false" ]; then
-            ALL_CHANGED_FILES=""
+          if [ "${{ inputs.only-build-modified }}" = "true" ]; then
+            get_bitbake_targets_args="${{ steps.changed-files.outputs.all_changed_files }}"
+          else
+            get_bitbake_targets_args=""
           fi
           TARGETS=$(
             $GITHUB_WORKSPACE/meta-lts-collab/scripts/get-bitbake-targets.py \
-              $ALL_CHANGED_FILES
+              ${get_bitbake_targets_args}
           )
           echo "build_targets=$TARGETS" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -9,6 +9,9 @@ on:  # yamllint disable-line rule:truthy
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: 'Lint scripts & CI'


### PR DESCRIPTION
The changed-files action fails when running in push-periodic. Updates logic where the action only runs if only-build-modified is set to true.