### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -74,7 +74,7 @@ jobs:
           path: |
             ${{ github.workspace }}/build/downloads
             ${{ github.workspace }}/build/sstate-cache
-          key: ${{ runner.name }}-downloads-and-sstate
+          key: downloads-and-sstate-${{ inputs.branch }}
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -89,8 +89,12 @@ jobs:
           else
             get_bitbake_targets_args=""
           fi
+          # changed-files outputs filepaths relative to the repository root
+          # although get-bitbake-targets.py can be called from anywhere, it's
+          # easiest to just cd to the repository root when running this command.
           TARGETS=$(
-            $GITHUB_WORKSPACE/meta-lts-collab/scripts/get-bitbake-targets.py \
+            cd $GITHUB_WORKSPACE/meta-lts-collab &&
+            ./scripts/get-bitbake-targets.py \
               ${get_bitbake_targets_args}
           )
           echo "build_targets=$TARGETS" >> $GITHUB_OUTPUT

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -1,0 +1,23 @@
+---
+name: Clear existing cache
+
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      cache-key:
+        required: true
+        type: string
+
+permissions:
+  actions: write
+
+jobs:
+  delete-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete cache
+        env:
+          CACHE_KEY: ${{ inputs.cache-key }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh cache delete "${CACHE_KEY}" --repo "${GITHUB_REPOSITORY}" --succeed-on-no-caches

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
     needs: lint
     uses: ./.github/workflows/bitbake-common.yml
     with:
-      branch: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+      branch: ${{ github.base_ref }}
       only-build-modified: false
       parse-only: true
       runner: ubuntu-22.04
@@ -27,7 +27,7 @@ jobs:
     needs: parse
     uses: ./.github/workflows/bitbake-common.yml
     with:
-      branch: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+      branch: ${{ github.base_ref }}
       only-build-modified: true
       parse-only: false
       runner: yocto_build_host

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,6 +21,7 @@ jobs:
       only-build-modified: false
       parse-only: true
       runner: ubuntu-22.04
+      use-cache: false
 
   build:
     name: 'Build recipes'

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -23,6 +23,11 @@ jobs:
       parse-only: true
       runner: ubuntu-22.04
 
+  clear-cache:  # We will always need to clear out the cache until more cache space is available
+    uses: ./.github/workflows/clear-cache.yml
+    with:
+      cache-key: downloads-and-sstate-${{ github.ref_name }}
+
   build:
     needs: parse
     uses: ./.github/workflows/bitbake-common.yml

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -22,6 +22,7 @@ jobs:
       only-build-modified: false
       parse-only: true
       runner: ubuntu-22.04
+      use-cache: false
 
   clear-cache:  # We will always need to clear out the cache until more cache space is available
     uses: ./.github/workflows/clear-cache.yml

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -18,7 +18,7 @@ jobs:
     needs: lint
     uses: ./.github/workflows/bitbake-common.yml
     with:
-      branch: ${{ github.ref }}
+      branch: ${{ github.ref_name }}
       only-build-modified: false
       parse-only: true
       runner: ubuntu-22.04
@@ -27,7 +27,7 @@ jobs:
     needs: parse
     uses: ./.github/workflows/bitbake-common.yml
     with:
-      branch: ${{ github.ref }}
+      branch: ${{ github.ref_name }}
       only-build-modified: false
       parse-only: false
       runner: yocto_build_host


### PR DESCRIPTION
Several issues existed with caching:

- Cache was being downloaded for the parse job
    - The cache requires too much space for the runner that runs the parse job
    - Solution: Caching has been disabled
- Cache names were unique because of runner.name having a unique ID per runner instance
    - This was causing cache misses
    - We can only support one cache key at at time because one cache is ~9 GiB
    - Solution: Renamed key to a value that leaves one key per branch
- A uploading a duplicate cache key will fail
    - Solution: Added a higher scope workflow to clear out the cache at the start of push/periodic jobs
        - This will also ensure the cache doesn't slowly grow to exceed 10 GiB while that is the limit
        - This does make it where the push/periodic workflows build without a cache... :cry: 

I'd like to revisit caching in the future if we can get more cache space. I think appending `${{ runner.name }}` to the new key and adding `restore-keys: downloads-and-sstate-${{ inputs.branch }}` to the cache-restore step will allow for multiple cache keys per branch. We can then get rid of the cache clearing reusable workflow as GitHub's automatic eviction would handle pruning the old cache keys that are no longer used.

Also, the changed-files action pass relative paths to the repository root, which is not the same as the github workdir. This is because of how CI clones meta-lts-collab to the workdir along with poky and meta-oe. I updated the call to get-bitbake-targets.py to be called from the meta-lts-collab to quickly enure that the relative paths are resolved properly.