### PR TITLE
Fix clear cache

### DIFF
--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -25,6 +25,8 @@ jobs:
       use-cache: false
 
   clear-cache:  # We will always need to clear out the cache until more cache space is available
+    permissions:
+      actions: write
     uses: ./.github/workflows/clear-cache.yml
     with:
       cache-key: downloads-and-sstate-${{ github.ref_name }}

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -32,7 +32,7 @@ jobs:
       cache-key: downloads-and-sstate-${{ github.ref_name }}
 
   build:
-    needs: parse
+    needs: [parse, clear-cache]
     uses: ./.github/workflows/bitbake-common.yml
     with:
       branch: ${{ github.ref_name }}


### PR DESCRIPTION
Ensures build has a dependency on clear-cache and sets up permissions correctly for clear-cache in the push-periodic workflow.