### PR TITLE
ci: Fix cache deletion command

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -20,4 +20,4 @@ jobs:
           CACHE_KEY: ${{ inputs.cache-key }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh cache delete "${CACHE_KEY}" --repo "${GITHUB_REPOSITORY}" --succeed-on-no-caches
+          gh cache delete "${CACHE_KEY}" --repo "${GITHUB_REPOSITORY}" || true


### PR DESCRIPTION
Removes --succeed-on-no-caches since the flag must be used with the "--all" flag. Instead, "|| true" is appended to ensure the command always returns true.