### PR TITLE
Reduce cache rebuilds

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -7,6 +7,10 @@ on:  # yamllint disable-line rule:truthy
       cache-key:
         required: true
         type: string
+      skip-clear:
+        default: false
+        required: false
+        type: boolean
 
 permissions:
   actions: write
@@ -15,7 +19,12 @@ jobs:
   delete-cache:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip deleting cache
+        if: ${{ inputs.skip-clear }}
+        run: |
+          echo "Skipping cache deletion"
       - name: Delete cache
+        if: ${{ !inputs.skip-clear }}
         env:
           CACHE_KEY: ${{ inputs.cache-key }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -30,6 +30,7 @@ jobs:
     uses: ./.github/workflows/clear-cache.yml
     with:
       cache-key: downloads-and-sstate-${{ github.ref_name }}
+      skip-clear: ${{ github.event_name == 'push' }}
 
   build:
     needs: [parse, clear-cache]
@@ -39,4 +40,5 @@ jobs:
       only-build-modified: false
       parse-only: false
       runner: yocto_build_host
-      save-cache: true
+      save-cache: ${{ github.event_name == 'schedule' }}
+      use-cache: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
This change updates push workflows to use the existing cache instead of rebuilding the cache.

Right now, if a PR is merged, the cache will be empty for ~1.5 hours while the push workflow rebuilds the cache. Although the rebuilt sstate and download cache will exactly match building from the tip of the dunfell branch, any PRs that are submitted or updated while the cache is being rebuilt will trigger CI to run without a cache. This means there is a ~1.5 hour window where build jobs will have to do a full build, compounding the amount of CI resources spent.

Limiting cache rebuilding to only the weekly full build will keep the downloads and sstate cache behind where the Dunfell branch may end up by the end of the week. However, the build time penalty for using an older sstate cache will be less than the time penalty of rebuilding the cache each push along with PRs performing full builds.

If more cache space is allowed in the future, both push and schedule workflows could use an existing cache and publish a new cache, which will allow the cache to stay up to date with much faster build times and no windows where no cache is available.