### PR TITLE
Enhance caching

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Default owners
+* @colin-pm @bwerl
+
+# CI & Script configurations
+/.github/ @colin-pm @same-code-different-day
+/scripts/ @colin-pm @same-code-different-day

--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -74,7 +74,9 @@ jobs:
           path: |
             ${{ github.workspace }}/build/downloads
             ${{ github.workspace }}/build/sstate-cache
-          key: downloads-and-sstate-${{ inputs.branch }}
+          key: downloads-and-sstate-${{ inputs.branch }}-${{ runner.name }}
+          restore-keys: |
+            downloads-and-sstate-${{ inputs.branch }}
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -4,9 +4,6 @@ name: Clear existing cache
 on:  # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
-      cache-key:
-        required: true
-        type: string
       skip-clear:
         default: false
         required: false
@@ -26,7 +23,6 @@ jobs:
       - name: Delete cache
         if: ${{ !inputs.skip-clear }}
         env:
-          CACHE_KEY: ${{ inputs.cache-key }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh cache delete "${CACHE_KEY}" --repo "${GITHUB_REPOSITORY}" || true
+          gh cache delete --all --repo "${GITHUB_REPOSITORY}" --succeed-on-no-caches

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -29,8 +29,7 @@ jobs:
       actions: write
     uses: ./.github/workflows/clear-cache.yml
     with:
-      cache-key: downloads-and-sstate-${{ github.ref_name }}
-      skip-clear: ${{ github.event_name == 'push' }}
+      skip-clear: ${{ github.event_name != 'schedule' }}
 
   build:
     needs: [parse, clear-cache]

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -39,5 +39,5 @@ jobs:
       only-build-modified: false
       parse-only: false
       runner: yocto_build_host
-      save-cache: ${{ github.event_name == 'schedule' }}
+      save-cache: true
       use-cache: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
After reading the docs more, it appears that GitHub will support removing the old cache if the new cache is less than the 10 GiB maximum, but old cache and new cache exceed the 10 GiB limit. I would like to have push events update the cache so the cache don't get far out of sync with the tip of the branch.

I've seen that over the week the build times go up, especially if a change is merged that invalidates a large slice of sstate. Saving a new cache on each push will ensure that the cache stays in sync and build times remain fast for PRs.

The weekly periodic job will still clear out the cache before rebuilding the cache from scratch. This ensures that the sstate cache doesn't continue to grow week-to-week and exceed the 10 GiB limit.

Also, I did add a codeowners file to ensure that at least one person is added as a reviewer for any PR that comes in. I'll add the two others referenced in the file to approve this PR before I merge to ensure everyone agrees to the current configuration. This is an initial configuration and will be subject to change if more maintainers are needed.