### PR TITLE
ci: Fix key for periodic cache saves

### DIFF
--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -129,4 +129,4 @@ jobs:
           path: |
             ${{ github.workspace }}/build/downloads
             ${{ github.workspace }}/build/sstate-cache
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+          key: downloads-and-sstate-${{ inputs.branch }}-${{ runner.name }}


### PR DESCRIPTION
Reusing the cache-restore primary key for the cache save step does not work for the periodic weekly job since the cache restore step is skipped. Duplicating the cache key for both steps is not ideal, but ensures that the periodic weekly job properly saves the cache.