### PR TITLE
oe: openjpeg: Ignore CVE-2025-54874

### DIFF
--- a/meta-oe/recipes-graphics/openjpeg/openjpeg_2.3.1.bbappend
+++ b/meta-oe/recipes-graphics/openjpeg/openjpeg_2.3.1.bbappend
@@ -3,3 +3,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI_append = " \
     file://CVE-2021-3575.patch \
 "
+
+# cpe-incorrect:
+# Introduced in v2.5.1 by commit 0f528e9
+# https://github.com/uclouvain/openjpeg/pull/1573
+CVE_CHECK_WHITELIST += "CVE-2025-54874"


### PR DESCRIPTION
CVE-2025-54874 does not affect openjpeg v2.3.1 so it can be ignored.