### PR TITLE
core: glibc: Backport fix for CVE-2026-0915

### DIFF
--- a/meta-core/recipes-core/glibc/glibc/CVE-2026-0915.patch
+++ b/meta-core/recipes-core/glibc/glibc/CVE-2026-0915.patch
@@ -1,0 +1,80 @@
+From 8945586275d18c2b04a8ad7ad88da3d811fe6625 Mon Sep 17 00:00:00 2001
+From: Carlos O'Donell <carlos@redhat.com>
+Date: Thu, 15 Jan 2026 15:09:38 -0500
+Subject: [PATCH] resolv: Fix NSS DNS backend for getnetbyaddr (CVE-2026-0915)
+
+The default network value of zero for net was never tested for and
+results in a DNS query constructed from uninitialized stack bytes.
+The solution is to provide a default query for the case where net
+is zero.
+
+Adding a test case for this was straight forward given the existence of
+tst-resolv-network and if the test is added without the fix you observe
+this failure:
+
+FAIL: resolv/tst-resolv-network
+original exit status 1
+error: tst-resolv-network.c:174: invalid QNAME: \146\218\129\128
+error: 1 test failures
+
+With a random QNAME resulting from the use of uninitialized stack bytes.
+
+After the fix the test passes.
+
+Additionally verified using wireshark before and after to ensure
+on-the-wire bytes for the DNS query were as expected.
+
+No regressions on x86_64.
+
+Reviewed-by: Florian Weimer <fweimer@redhat.com>
+
+CVE: CVE-2026-0915
+Upstream-Status: Backport [https://sourceware.org/git/?p=glibc.git;a=commit;h=e56ff82d5034ec66c6a78f517af6faa427f65b0b]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ resolv/nss_dns/dns-network.c | 4 ++++
+ resolv/tst-resolv-network.c  | 6 ++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/resolv/nss_dns/dns-network.c b/resolv/nss_dns/dns-network.c
+index 906a3a6b06..f6b1bdce4b 100644
+--- a/resolv/nss_dns/dns-network.c
++++ b/resolv/nss_dns/dns-network.c
+@@ -207,6 +207,10 @@ _nss_dns_getnetbyaddr_r (uint32_t net, int type, struct netent *result,
+       sprintf (qbuf, "%u.%u.%u.%u.in-addr.arpa", net_bytes[3], net_bytes[2],
+ 	       net_bytes[1], net_bytes[0]);
+       break;
++    default:
++      /* Default network (net is originally zero).  */
++      strcpy (qbuf, "0.0.0.0.in-addr.arpa");
++      break;
+     }
+ 
+   net_buffer.buf = orig_net_buffer = (querybuf *) alloca (1024);
+diff --git a/resolv/tst-resolv-network.c b/resolv/tst-resolv-network.c
+index a91699c711..fefa4f25c2 100644
+--- a/resolv/tst-resolv-network.c
++++ b/resolv/tst-resolv-network.c
+@@ -46,6 +46,9 @@ handle_code (const struct resolv_response_context *ctx,
+ {
+   switch (code)
+     {
++    case 0:
++      send_ptr (b, qname, qclass, qtype, "0.in-addr.arpa");
++      break;
+     case 1:
+       send_ptr (b, qname, qclass, qtype, "1.in-addr.arpa");
+       break;
+@@ -265,6 +268,9 @@ do_test (void)
+                 "error: TRY_AGAIN\n");
+ 
+   /* Lookup by address, success cases.  */
++  check_reverse (0,
++                 "name: 0.in-addr.arpa\n"
++                 "net: 0x00000000\n");
+   check_reverse (1,
+                  "name: 1.in-addr.arpa\n"
+                  "net: 0x00000001\n");
+-- 
+2.52.0
+

--- a/meta-core/recipes-core/glibc/glibc_2.31%.bbappend
+++ b/meta-core/recipes-core/glibc/glibc_2.31%.bbappend
@@ -9,4 +9,5 @@ SRC_URI_append = " \
     file://CVE-2024-33600-01.patch \
     file://CVE-2024-33600-02.patch \
     file://CVE-2024-33601-CVE-2024-33602.patch \
+    file://CVE-2026-0915.patch \
     "


### PR DESCRIPTION
Backports the fix for CVE-2026-0915 from
https://sourceware.org/git/?p=glibc.git;a=commit;h=e56ff82d5034ec66c6a78f517af6faa427f65b0b