### PR TITLE
Backport CVE fixes for openssl

### DIFF
--- a/meta-core/recipes-connectivity/openssl/openssl/CVE-2025-68160.patch
+++ b/meta-core/recipes-connectivity/openssl/openssl/CVE-2025-68160.patch
@@ -1,0 +1,82 @@
+From e9c13f360280011f01e4e33e626814b7c4e5cc80 Mon Sep 17 00:00:00 2001
+From: Neil Horman <nhorman@openssl.org>
+Date: Wed, 7 Jan 2026 11:52:09 -0500
+Subject: [PATCH] Fix heap buffer overflow in BIO_f_linebuffer
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When a FIO_f_linebuffer is part of a bio chain, and the next BIO
+preforms short writes, the remainder of the unwritten buffer is copied
+unconditionally to the internal buffer ctx->obuf, which may not be
+sufficiently sized to handle the remaining data, resulting in a buffer
+overflow.
+
+Fix it by only copying data when ctx->obuf has space, flushing to the
+next BIO to increase available storage if needed.
+
+Fixes openssl/srt#48
+
+Fixes CVE-2025-68160
+
+Reviewed-by: Nikola Pajkovsky <nikolap@openssl.org>
+Reviewed-by: Eugene Syromiatnikov <esyr@openssl.org>
+Reviewed-by: Saša Nedvědický <sashan@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+MergeDate: Mon Jan 26 19:41:40 2026
+
+CVE: CVE-2025-68160
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/b21663c35a6f0ed4c8de06855bdc7a6a21f00c2f]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ crypto/bio/bf_lbuf.c | 32 ++++++++++++++++++++++++++------
+ 1 file changed, 26 insertions(+), 6 deletions(-)
+
+diff --git a/crypto/bio/bf_lbuf.c b/crypto/bio/bf_lbuf.c
+index 72f9901813..34dd0357d8 100644
+--- a/crypto/bio/bf_lbuf.c
++++ b/crypto/bio/bf_lbuf.c
+@@ -191,14 +191,34 @@ static int linebuffer_write(BIO *b, const char *in, int inl)
+     while (foundnl && inl > 0);
+     /*
+      * We've written as much as we can.  The rest of the input buffer, if
+-     * any, is text that doesn't and with a NL and therefore needs to be
+-     * saved for the next trip.
++     * any, is text that doesn't end with a NL and therefore we need to try
++     * free up some space in our obuf so we can make forward progress.
+      */
+-    if (inl > 0) {
+-        memcpy(&(ctx->obuf[ctx->obuf_len]), in, inl);
+-        ctx->obuf_len += inl;
+-        num += inl;
++    while (inl > 0) {
++        size_t avail = (size_t)ctx->obuf_size - (size_t)ctx->obuf_len;
++        size_t to_copy;
++
++        if (avail == 0) {
++            /* Flush buffered data to make room */
++            i = BIO_write(b->next_bio, ctx->obuf, ctx->obuf_len);
++            if (i <= 0) {
++                BIO_copy_next_retry(b);
++                return num > 0 ? num : i;
++            }
++            if (i < ctx->obuf_len)
++                memmove(ctx->obuf, ctx->obuf + i, ctx->obuf_len - i);
++            ctx->obuf_len -= i;
++            continue;
++        }
++
++        to_copy = inl > (int)avail ? avail : (size_t)inl;
++        memcpy(&(ctx->obuf[ctx->obuf_len]), in, to_copy);
++        ctx->obuf_len += (int)to_copy;
++        in += to_copy;
++        inl -= (int)to_copy;
++        num += (int)to_copy;
+     }
++
+     return num;
+ }
+ 
+-- 
+2.52.0
+

--- a/meta-core/recipes-connectivity/openssl/openssl/CVE-2025-69418.patch
+++ b/meta-core/recipes-connectivity/openssl/openssl/CVE-2025-69418.patch
@@ -1,0 +1,79 @@
+From 598ea163ac3fcf2579e866e4fab05a953ba50a2a Mon Sep 17 00:00:00 2001
+From: Norbert Pocs <norbertp@openssl.org>
+Date: Thu, 8 Jan 2026 15:04:54 +0100
+Subject: [PATCH] Fix OCB AES-NI/HW stream path unauthenticated/unencrypted
+ trailing bytes
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When ctx->stream (e.g., AES‑NI or ARMv8 CE) is available, the fast path
+encrypts/decrypts full blocks but does not advance in/out pointers. The
+tail-handling code then operates on the base pointers, effectively reprocessing
+the beginning of the buffer while leaving the actual trailing bytes
+unencrypted (encryption) or using the wrong plaintext (decryption). The
+authentication checksum excludes the true tail.
+
+CVE-2025-69418
+
+Fixes: https://github.com/openssl/srt/issues/58
+
+Signed-off-by: Norbert Pocs <norbertp@openssl.org>
+
+Reviewed-by: Saša Nedvědický <sashan@openssl.org>
+Reviewed-by: Eugene Syromiatnikov <esyr@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+MergeDate: Mon Jan 26 19:48:35 2026
+
+CVE: CVE-2025-69418
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/be9375d5d45dfaf897b56ef148a0b58402491fcb]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ crypto/modes/ocb128.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/modes/ocb128.c b/crypto/modes/ocb128.c
+index b39a55a1a1..2ef39826d0 100644
+--- a/crypto/modes/ocb128.c
++++ b/crypto/modes/ocb128.c
+@@ -342,7 +342,7 @@ int CRYPTO_ocb128_encrypt(OCB128_CONTEXT *ctx,
+ 
+     if (num_blocks && all_num_blocks == (size_t)all_num_blocks
+         && ctx->stream != NULL) {
+-        size_t max_idx = 0, top = (size_t)all_num_blocks;
++        size_t max_idx = 0, top = (size_t)all_num_blocks, processed_bytes = 0;
+ 
+         /*
+          * See how many L_{i} entries we need to process data at hand
+@@ -356,6 +356,9 @@ int CRYPTO_ocb128_encrypt(OCB128_CONTEXT *ctx,
+         ctx->stream(in, out, num_blocks, ctx->keyenc,
+                     (size_t)ctx->sess.blocks_processed + 1, ctx->sess.offset.c,
+                     (const unsigned char (*)[16])ctx->l, ctx->sess.checksum.c);
++        processed_bytes = num_blocks * 16;
++        in += processed_bytes;
++        out += processed_bytes;
+     } else {
+         /* Loop through all full blocks to be encrypted */
+         for (i = ctx->sess.blocks_processed + 1; i <= all_num_blocks; i++) {
+@@ -434,7 +437,7 @@ int CRYPTO_ocb128_decrypt(OCB128_CONTEXT *ctx,
+ 
+     if (num_blocks && all_num_blocks == (size_t)all_num_blocks
+         && ctx->stream != NULL) {
+-        size_t max_idx = 0, top = (size_t)all_num_blocks;
++        size_t max_idx = 0, top = (size_t)all_num_blocks, processed_bytes = 0;
+ 
+         /*
+          * See how many L_{i} entries we need to process data at hand
+@@ -448,6 +451,9 @@ int CRYPTO_ocb128_decrypt(OCB128_CONTEXT *ctx,
+         ctx->stream(in, out, num_blocks, ctx->keydec,
+                     (size_t)ctx->sess.blocks_processed + 1, ctx->sess.offset.c,
+                     (const unsigned char (*)[16])ctx->l, ctx->sess.checksum.c);
++        processed_bytes = num_blocks * 16;
++        in += processed_bytes;
++        out += processed_bytes;
+     } else {
+         OCB_BLOCK tmp;
+ 
+-- 
+2.52.0
+

--- a/meta-core/recipes-connectivity/openssl/openssl/CVE-2025-69419.patch
+++ b/meta-core/recipes-connectivity/openssl/openssl/CVE-2025-69419.patch
@@ -1,0 +1,65 @@
+From 626ff41df6069f3994206160279f038e02273886 Mon Sep 17 00:00:00 2001
+From: Norbert Pocs <norbertp@openssl.org>
+Date: Thu, 11 Dec 2025 12:49:00 +0100
+Subject: [PATCH] Check return code of UTF8_putc
+
+Signed-off-by: Norbert Pocs <norbertp@openssl.org>
+
+Reviewed-by: Nikola Pajkovsky <nikolap@openssl.org>
+Reviewed-by: Viktor Dukhovni <viktor@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/29376)
+
+CVE: CVE-2025-69419
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/ff628933755075446bca8307e8417c14d164b535]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ crypto/asn1/a_strex.c   |  6 ++++--
+ crypto/pkcs12/p12_utl.c | 15 +++++++++++----
+ 2 files changed, 15 insertions(+), 6 deletions(-)
+
+diff --git a/crypto/asn1/a_strex.c b/crypto/asn1/a_strex.c
+index 284dde274c..843b0f9461 100644
+--- a/crypto/asn1/a_strex.c
++++ b/crypto/asn1/a_strex.c
+@@ -203,8 +203,10 @@ static int do_buf(unsigned char *buf, int buflen,
+             orflags = CHARTYPE_LAST_ESC_2253;
+         if (type & BUF_TYPE_CONVUTF8) {
+             unsigned char utfbuf[6];
+-            int utflen;
+-            utflen = UTF8_putc(utfbuf, sizeof(utfbuf), c);
++            int utflen = UTF8_putc(utfbuf, sizeof(utfbuf), c);
++
++            if (utflen < 0)
++                return -1; /* error happened with UTF8 */
+             for (i = 0; i < utflen; i++) {
+                 /*
+                  * We don't need to worry about setting orflags correctly
+diff --git a/crypto/pkcs12/p12_utl.c b/crypto/pkcs12/p12_utl.c
+index 43b9e3a594..5ddf152467 100644
+--- a/crypto/pkcs12/p12_utl.c
++++ b/crypto/pkcs12/p12_utl.c
+@@ -205,10 +205,17 @@ char *OPENSSL_uni2utf8(const unsigned char *uni, int unilen)
+     }
+ 
+     /* re-run the loop emitting UTF-8 string */
+-    for (asclen = 0, i = 0; i < unilen; ) {
+-        j = bmp_to_utf8(asctmp+asclen, uni+i, unilen-i);
+-        if (j == 4) i += 4;
+-        else        i += 2;
++    for (asclen = 0, i = 0; i < unilen;) {
++        j = bmp_to_utf8(asctmp + asclen, uni + i, unilen - i);
++        /* when UTF8_putc fails */
++        if (j < 0) {
++            OPENSSL_free(asctmp);
++            return NULL;
++        }
++        if (j == 4)
++            i += 4;
++        else
++            i += 2;
+         asclen += j;
+     }
+ 
+-- 
+2.52.0
+

--- a/meta-core/recipes-connectivity/openssl/openssl/CVE-2025-69420.patch
+++ b/meta-core/recipes-connectivity/openssl/openssl/CVE-2025-69420.patch
@@ -1,0 +1,52 @@
+From 4ce488233fe7645814de2d972654bc99d8ba04e2 Mon Sep 17 00:00:00 2001
+From: Bob Beck <beck@openssl.org>
+Date: Wed, 7 Jan 2026 11:29:48 -0700
+Subject: [PATCH] Verify ASN1 object's types before attempting to access them
+ as a particular type
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Issue was reported in ossl_ess_get_signing_cert but is also present in
+ossl_ess_get_signing_cert_v2.
+
+Fixes: https://github.com/openssl/srt/issues/61
+Fixes CVE-2025-69420
+
+Reviewed-by: Norbert Pocs <norbertp@openssl.org>
+Reviewed-by: Saša Nedvědický <sashan@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+MergeDate: Mon Jan 26 19:53:36 2026
+
+CVE: CVE-2025-69420
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/ea8fc4c345fbd749048809c9f7c881ea656b0b94]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ crypto/ts/ts_rsp_verify.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/ts/ts_rsp_verify.c b/crypto/ts/ts_rsp_verify.c
+index 7fe3d27e74..5d452d2660 100644
+--- a/crypto/ts/ts_rsp_verify.c
++++ b/crypto/ts/ts_rsp_verify.c
+@@ -262,7 +262,7 @@ static ESS_SIGNING_CERT *ess_get_signing_cert(PKCS7_SIGNER_INFO *si)
+     ASN1_TYPE *attr;
+     const unsigned char *p;
+     attr = PKCS7_get_signed_attribute(si, NID_id_smime_aa_signingCertificate);
+-    if (!attr)
++    if (attr == NULL || attr->type != V_ASN1_SEQUENCE)
+         return NULL;
+     p = attr->value.sequence->data;
+     return d2i_ESS_SIGNING_CERT(NULL, &p, attr->value.sequence->length);
+@@ -274,7 +274,7 @@ static ESS_SIGNING_CERT_V2 *ess_get_signing_cert_v2(PKCS7_SIGNER_INFO *si)
+     const unsigned char *p;
+ 
+     attr = PKCS7_get_signed_attribute(si, NID_id_smime_aa_signingCertificateV2);
+-    if (attr == NULL)
++    if (attr == NULL || attr->type != V_ASN1_SEQUENCE)
+         return NULL;
+     p = attr->value.sequence->data;
+     return d2i_ESS_SIGNING_CERT_V2(NULL, &p, attr->value.sequence->length);
+-- 
+2.52.0
+

--- a/meta-core/recipes-connectivity/openssl/openssl/CVE-2026-22795-CVE-2026-22796.patch
+++ b/meta-core/recipes-connectivity/openssl/openssl/CVE-2026-22795-CVE-2026-22796.patch
@@ -1,0 +1,78 @@
+From fc03a1055140fbf2fec5e1109a0ff0222e6bfe1c Mon Sep 17 00:00:00 2001
+From: Bob Beck <beck@openssl.org>
+Date: Wed, 7 Jan 2026 11:29:48 -0700
+Subject: [PATCH] Ensure ASN1 types are checked before use.
+
+Some of these were fixed by LibreSSL in commit https://github.com/openbsd/src/commit/aa1f637d454961d22117b4353f98253e984b3ba8
+this fix includes the other fixes in that commit, as well as fixes for others found by a scan
+for a similar unvalidated access paradigm in the tree.
+
+Reviewed-by: Kurt Roeckx <kurt@roeckx.be>
+Reviewed-by: Shane Lontis <shane.lontis@oracle.com>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/29582)
+
+CVE: CVE-2026-22795 CVE-2026-22796
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/2502e7b7d4c0cf4f972a881641fe09edc67aeec4]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ apps/s_client.c          |  3 ++-
+ crypto/pkcs12/p12_kiss.c | 10 ++++++++--
+ crypto/pkcs7/pk7_doit.c  |  2 ++
+ 3 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/apps/s_client.c b/apps/s_client.c
+index 00effc8037..39df178ce8 100644
+--- a/apps/s_client.c
++++ b/apps/s_client.c
+@@ -2698,8 +2698,9 @@ int s_client_main(int argc, char **argv)
+                 goto end;
+             }
+             atyp = ASN1_generate_nconf(genstr, cnf);
+-            if (atyp == NULL) {
++            if (atyp == NULL || atyp->type != V_ASN1_SEQUENCE) {
+                 NCONF_free(cnf);
++                ASN1_TYPE_free(atyp);
+                 BIO_printf(bio_err, "ASN1_generate_nconf failed\n");
+                 goto end;
+             }
+diff --git a/crypto/pkcs12/p12_kiss.c b/crypto/pkcs12/p12_kiss.c
+index 7ab98385a7..d90404ddf6 100644
+--- a/crypto/pkcs12/p12_kiss.c
++++ b/crypto/pkcs12/p12_kiss.c
+@@ -183,11 +183,17 @@ static int parse_bag(PKCS12_SAFEBAG *bag, const char *pass, int passlen,
+     ASN1_BMPSTRING *fname = NULL;
+     ASN1_OCTET_STRING *lkid = NULL;
+ 
+-    if ((attrib = PKCS12_SAFEBAG_get0_attr(bag, NID_friendlyName)))
++    if ((attrib = PKCS12_SAFEBAG_get0_attr(bag, NID_friendlyName))) {
++        if (attrib->type != V_ASN1_BMPSTRING)
++            return 0;
+         fname = attrib->value.bmpstring;
++    }
+ 
+-    if ((attrib = PKCS12_SAFEBAG_get0_attr(bag, NID_localKeyID)))
++    if ((attrib = PKCS12_SAFEBAG_get0_attr(bag, NID_localKeyID))) {
++        if (attrib->type != V_ASN1_OCTET_STRING)
++            return 0;
+         lkid = attrib->value.octet_string;
++    }
+ 
+     switch (PKCS12_SAFEBAG_get_nid(bag)) {
+     case NID_keyBag:
+diff --git a/crypto/pkcs7/pk7_doit.c b/crypto/pkcs7/pk7_doit.c
+index f63fbc50ea..4e0eb1e830 100644
+--- a/crypto/pkcs7/pk7_doit.c
++++ b/crypto/pkcs7/pk7_doit.c
+@@ -1092,6 +1092,8 @@ ASN1_OCTET_STRING *PKCS7_digest_from_attributes(STACK_OF(X509_ATTRIBUTE) *sk)
+     ASN1_TYPE *astype;
+     if ((astype = get_attribute(sk, NID_pkcs9_messageDigest)) == NULL)
+         return NULL;
++    if (astype->type != V_ASN1_OCTET_STRING)
++        return NULL;
+     return astype->value.octet_string;
+ }
+ 
+-- 
+2.52.0
+

--- a/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
+++ b/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
@@ -5,4 +5,5 @@ SRC_URI_append = " \
     file://CVE-2025-69418.patch \
     file://CVE-2025-69419.patch \
     file://CVE-2025-69420.patch \
+    file://CVE-2026-22795-CVE-2026-22796.patch \
     "

--- a/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
+++ b/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI_append = " \
     file://CVE-2025-68160.patch \
+    file://CVE-2025-69418.patch \
     "

--- a/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
+++ b/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
@@ -3,4 +3,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI_append = " \
     file://CVE-2025-68160.patch \
     file://CVE-2025-69418.patch \
+    file://CVE-2025-69419.patch \
     "

--- a/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
+++ b/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI_append = " \
+    file://CVE-2025-68160.patch \
+    "

--- a/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
+++ b/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
@@ -4,4 +4,5 @@ SRC_URI_append = " \
     file://CVE-2025-68160.patch \
     file://CVE-2025-69418.patch \
     file://CVE-2025-69419.patch \
+    file://CVE-2025-69420.patch \
     "


### PR DESCRIPTION
Backport several CVE fixes for openssl on the dunfell branch:
CVE-2025-68160
CVE-2025-69418
CVE-2025-69419
CVE-2025-69420
CVE-2026-22795
CVE-2026-22796