### PR TITLE
core: glibc: Backport fix for CVE-2026-0861

### DIFF
--- a/meta-core/recipes-core/glibc/glibc/CVE-2026-0861.patch
+++ b/meta-core/recipes-core/glibc/glibc/CVE-2026-0861.patch
@@ -1,0 +1,93 @@
+From 8c70322388bb60055e8ad428ad3db81a0f925ff9 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@gotplt.org>
+Date: Thu, 15 Jan 2026 06:06:40 -0500
+Subject: [PATCH] memalign: reinstate alignment overflow check (CVE-2026-0861)
+
+The change to cap valid sizes to PTRDIFF_MAX inadvertently dropped the
+overflow check for alignment in memalign functions, _mid_memalign and
+_int_memalign.  Reinstate the overflow check in _int_memalign, aligned
+with the PTRDIFF_MAX change since that is directly responsible for the
+CVE.  The missing _mid_memalign check is not relevant (and does not have
+a security impact) and may need a different approach to fully resolve,
+so it has been omitted.
+
+CVE-Id: CVE-2026-0861
+Vulnerable-Commit: 9bf8e29ca136094f73f69f725f15c51facc97206
+Reported-by: Igor Morgenstern, Aisle Research
+Fixes: BZ #33796
+Reviewed-by: Wilco Dijkstra <Wilco.Dijkstra@arm.com>
+Signed-off-by: Siddhesh Poyarekar <siddhesh@gotplt.org>
+(cherry picked from commit c9188d333717d3ceb7e3020011651f424f749f93)
+
+CVE: CVE-2026-0861
+Upstream-Status: Backport [https://sourceware.org/git/?p=glibc.git;a=commit;h=f18446d7b4a423090ee5e328c36b3c2a0f26041c]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ malloc/malloc.c               |  8 +++++---
+ malloc/tst-malloc-too-large.c | 10 ++--------
+ 2 files changed, 7 insertions(+), 11 deletions(-)
+
+diff --git a/malloc/malloc.c b/malloc/malloc.c
+index f7cd29bc2f..1475182901 100644
+--- a/malloc/malloc.c
++++ b/malloc/malloc.c
+@@ -4668,7 +4668,7 @@ _int_memalign (mstate av, size_t alignment, size_t bytes)
+ 
+ 
+ 
+-  if (!checked_request2size (bytes, &nb))
++  if (!checked_request2size (bytes, &nb) || alignment > PTRDIFF_MAX)
+     {
+       __set_errno (ENOMEM);
+       return NULL;
+@@ -4679,8 +4679,10 @@ _int_memalign (mstate av, size_t alignment, size_t bytes)
+      request, and then possibly free the leading and trailing space.
+    */
+ 
+-  /* Call malloc with worst case padding to hit alignment. */
+-
++  /* Call malloc with worst case padding to hit alignment.  ALIGNMENT is a
++     power of 2, so it tops out at (PTRDIFF_MAX >> 1) + 1, leaving plenty of
++     space to add MINSIZE and whatever checked_request2size adds to BYTES to
++     get NB.  Consequently, total below also does not overflow.  */
+   m = (char *) (_int_malloc (av, nb + alignment + MINSIZE));
+ 
+   if (m == 0)
+diff --git a/malloc/tst-malloc-too-large.c b/malloc/tst-malloc-too-large.c
+index b5ad7eb7e7..03502e4295 100644
+--- a/malloc/tst-malloc-too-large.c
++++ b/malloc/tst-malloc-too-large.c
+@@ -127,7 +127,6 @@ test_large_allocations (size_t size)
+ }
+ 
+ 
+-static long pagesize;
+ 
+ /* This function tests the following aligned memory allocation functions
+    using several valid alignments and precedes each allocation test with a
+@@ -146,8 +145,8 @@ test_large_aligned_allocations (size_t size)
+ 
+   /* All aligned memory allocation functions expect an alignment that is a
+      power of 2.  Given this, we test each of them with every valid
+-     alignment from 1 thru PAGESIZE.  */
+-  for (align = 1; align <= pagesize; align *= 2)
++     alignment for the type of ALIGN, i.e. until it wraps to 0.  */
++  for (align = 1; align > 0; align <<= 1)
+     {
+       test_setup ();
+ #if __GNUC_PREREQ (7, 0)
+@@ -240,11 +239,6 @@ do_test (void)
+   DIAG_IGNORE_NEEDS_COMMENT (7, "-Walloc-size-larger-than=");
+ #endif
+ 
+-  /* Aligned memory allocation functions need to be tested up to alignment
+-     size equivalent to page size, which should be a power of 2.  */
+-  pagesize = sysconf (_SC_PAGESIZE);
+-  TEST_VERIFY_EXIT (powerof2 (pagesize));
+-
+   /* Loop 1: Ensure that all allocations with SIZE close to SIZE_MAX, i.e.
+      in the range (SIZE_MAX - 2^14, SIZE_MAX], fail.
+ 
+-- 
+2.52.0
+

--- a/meta-core/recipes-core/glibc/glibc_2.31%.bbappend
+++ b/meta-core/recipes-core/glibc/glibc_2.31%.bbappend
@@ -10,4 +10,5 @@ SRC_URI_append = " \
     file://CVE-2024-33600-02.patch \
     file://CVE-2024-33601-CVE-2024-33602.patch \
     file://CVE-2026-0915.patch \
+    file://CVE-2026-0861.patch \
     "


### PR DESCRIPTION
Backports the fix for CVE-2026-0861 from
https://sourceware.org/git/?p=glibc.git;a=commit;h=f18446d7b4a423090ee5e328c36b3c2a0f26041c