### PR TITLE
core: glibc: Backport fix for CVE-2025-15281

### DIFF
--- a/meta-core/recipes-core/glibc/glibc/CVE-2025-15281.patch
+++ b/meta-core/recipes-core/glibc/glibc/CVE-2025-15281.patch
@@ -1,0 +1,212 @@
+From 4b6588b2f9b3514ce14a27ba8a8399eaf47b03e1 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Thu, 15 Jan 2026 10:32:19 -0300
+Subject: [PATCH] posix: Reset wordexp_t fields with WRDE_REUSE (CVE-2025-15281
+ / BZ 33814)
+
+The wordexp fails to properly initialize the input wordexp_t when
+WRDE_REUSE is used. The wordexp_t struct is properly freed, but
+reuses the old wc_wordc value and updates the we_wordv in the
+wrong position.  A later wordfree will then call free with an
+invalid pointer.
+
+Checked on x86_64-linux-gnu and i686-linux-gnu.
+
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 80cc58ea2de214f85b0a1d902a3b668ad2ecb302)
+
+CVE: CVE-2025-15281
+Upstream-Status: Backport [https://sourceware.org/git/?p=glibc.git;a=commit;h=28eb5caf895ced5d895cb02757e109004a2d33e5]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ NEWS                      |  5 +++
+ posix/Makefile            | 17 ++++++--
+ posix/tst-wordexp-reuse.c | 89 +++++++++++++++++++++++++++++++++++++++
+ posix/wordexp.c           |  2 +
+ 4 files changed, 109 insertions(+), 4 deletions(-)
+ create mode 100644 posix/tst-wordexp-reuse.c
+
+diff --git a/NEWS b/NEWS
+index be489243ac..3db3b0a0b5 100644
+--- a/NEWS
++++ b/NEWS
+@@ -55,6 +55,8 @@ The following bugs are resolved with this release:
+   [28896] strncmp-avx2-rtm and wcsncmp-avx2-rtm fallback on non-rtm
+     variants when avoiding overflow
+   [29530] segfault in printf handling thousands separator
++  [33814] glob: wordexp with WRDE_REUSE and WRDE_APPEND may return
++    uninitialized memory
+ 
+ Security related changes:
+ 
+@@ -96,6 +98,9 @@ Security related changes:
+ 
+   CVE-2022-23218: Passing an overlong file name to the svcunix_create
+   legacy function could result in a stack-based buffer overflow.
++
++  CVE-2025-15281: wordexp with WRDE_REUSE and WRDE_APPEND may return
++  uninitialized memory.
+ 
+ Version 2.31
+ 
+diff --git a/posix/Makefile b/posix/Makefile
+index 4507d84bf1..16c5111df1 100644
+--- a/posix/Makefile
++++ b/posix/Makefile
+@@ -101,7 +101,8 @@ tests		:= test-errno tstgetopt testfnm runtests runptests \
+ 		   tst-sysconf-empty-chroot tst-glob_symlinks tst-fexecve \
+ 		   tst-glob-tilde test-ssize-max tst-spawn4 bug-regex37 \
+ 		   bug-regex38 tst-regcomp-truncated tst-spawn-chdir \
+-		   tst-wordexp-nocmd
++		   tst-wordexp-nocmd tst-wordexp-reuse
++
+ tests-internal	:= bug-regex5 bug-regex20 bug-regex33 \
+ 		   tst-rfc3484 tst-rfc3484-2 tst-rfc3484-3 \
+ 		   tst-glob_lstat_compat tst-spawn4-compat
+@@ -134,11 +135,13 @@ generated += $(addprefix wordexp-test-result, 1 2 3 4 5 6 7 8 9 10) \
+ 	     bug-glob2.mtrace bug-glob2-mem.out tst-vfork3-mem.out \
+ 	     tst-vfork3.mtrace getconf.speclist tst-fnmatch-mem.out \
+ 	     tst-fnmatch.mtrace bug-regex36.mtrace \
+-	     testcases.h ptestcases.h
++	     testcases.h ptestcases.h tst-wordexp-reuse-mem.out \
++	     tst-wordexp-reuse.mtrace
+ 
+ ifeq ($(run-built-tests),yes)
+ ifeq (yes,$(build-shared))
+-tests-special += $(objpfx)globtest.out $(objpfx)wordexp-tst.out
++tests-special += $(objpfx)globtest.out $(objpfx)wordexp-tst.out \
++		 $(objpfx)wordexp-tst.out
+ endif
+ endif
+ 
+@@ -152,7 +155,7 @@ tests-special += $(objpfx)bug-regex2-mem.out $(objpfx)bug-regex14-mem.out \
+ 		 $(objpfx)tst-boost-mem.out $(objpfx)tst-getconf.out \
+ 		 $(objpfx)bug-glob2-mem.out $(objpfx)tst-vfork3-mem.out \
+ 		 $(objpfx)tst-fnmatch-mem.out $(objpfx)bug-regex36-mem.out \
+-		 $(objpfx)tst-glob-tilde-mem.out
++		 $(objpfx)tst-glob-tilde-mem.out $(objpfx)tst-wordexp-reuse.out
+ xtests-special += $(objpfx)bug-ga2-mem.out
+ endif
+ 
+@@ -397,3 +400,9 @@ $(objpfx)posix-conf-vars-def.h: $(..)scripts/gen-posix-conf-vars.awk \
+ 	$(make-target-directory)
+ 	$(AWK) -f $(filter-out Makefile, $^) > $@.tmp
+ 	mv -f $@.tmp $@
++
++tst-wordexp-reuse-ENV += MALLOC_TRACE=$(objpfx)tst-wordexp-reuse.mtrace
++
++$(objpfx)tst-wordexp-reuse-mem.out: $(objpfx)tst-wordexp-reuse.out
++	$(common-objpfx)malloc/mtrace $(objpfx)tst-wordexp-reuse.mtrace > $@; \
++	$(evaluate-test)
+diff --git a/posix/tst-wordexp-reuse.c b/posix/tst-wordexp-reuse.c
+new file mode 100644
+index 0000000000..3926b9f557
+--- /dev/null
++++ b/posix/tst-wordexp-reuse.c
+@@ -0,0 +1,89 @@
++/* Test for wordexp with WRDE_REUSE flag.
++   Copyright (C) 2026 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <wordexp.h>
++#include <mcheck.h>
++
++#include <support/check.h>
++
++static int
++do_test (void)
++{
++  mtrace ();
++
++  {
++    wordexp_t p = { 0 };
++    TEST_COMPARE (wordexp ("one", &p, 0), 0);
++    TEST_COMPARE (p.we_wordc, 1);
++    TEST_COMPARE_STRING (p.we_wordv[0], "one");
++    TEST_COMPARE (wordexp ("two", &p, WRDE_REUSE), 0);
++    TEST_COMPARE (p.we_wordc, 1);
++    TEST_COMPARE_STRING (p.we_wordv[0], "two");
++    wordfree (&p);
++  }
++
++  {
++    wordexp_t p = { .we_offs = 2 };
++    TEST_COMPARE (wordexp ("one", &p, 0), 0);
++    TEST_COMPARE (p.we_wordc, 1);
++    TEST_COMPARE_STRING (p.we_wordv[0], "one");
++    TEST_COMPARE (wordexp ("two", &p, WRDE_REUSE | WRDE_DOOFFS), 0);
++    TEST_COMPARE (p.we_wordc, 1);
++    TEST_COMPARE_STRING (p.we_wordv[p.we_offs + 0], "two");
++    wordfree (&p);
++  }
++
++  {
++    wordexp_t p = { 0 };
++    TEST_COMPARE (wordexp ("one", &p, 0), 0);
++    TEST_COMPARE (p.we_wordc, 1);
++    TEST_COMPARE_STRING (p.we_wordv[0], "one");
++    TEST_COMPARE (wordexp ("two", &p, WRDE_REUSE | WRDE_APPEND), 0);
++    TEST_COMPARE (p.we_wordc, 1);
++    TEST_COMPARE_STRING (p.we_wordv[0], "two");
++    wordfree (&p);
++  }
++
++  {
++    wordexp_t p = { .we_offs = 2 };
++    TEST_COMPARE (wordexp ("one", &p, WRDE_DOOFFS), 0);
++    TEST_COMPARE (p.we_wordc, 1);
++    TEST_COMPARE_STRING (p.we_wordv[p.we_offs + 0], "one");
++    TEST_COMPARE (wordexp ("two", &p, WRDE_REUSE
++				      | WRDE_DOOFFS), 0);
++    TEST_COMPARE (p.we_wordc, 1);
++    TEST_COMPARE_STRING (p.we_wordv[p.we_offs + 0], "two");
++    wordfree (&p);
++  }
++
++  {
++    wordexp_t p = { .we_offs = 2 };
++    TEST_COMPARE (wordexp ("one", &p, WRDE_DOOFFS), 0);
++    TEST_COMPARE (p.we_wordc, 1);
++    TEST_COMPARE_STRING (p.we_wordv[p.we_offs + 0], "one");
++    TEST_COMPARE (wordexp ("two", &p, WRDE_REUSE
++				      | WRDE_DOOFFS | WRDE_APPEND), 0);
++    TEST_COMPARE (p.we_wordc, 1);
++    TEST_COMPARE_STRING (p.we_wordv[p.we_offs + 0], "two");
++    wordfree (&p);
++  }
++
++  return 0;
++}
++
++#include <support/test-driver.c>
+diff --git a/posix/wordexp.c b/posix/wordexp.c
+index 56289503a1..866603b1ed 100644
+--- a/posix/wordexp.c
++++ b/posix/wordexp.c
+@@ -2220,7 +2220,9 @@ wordexp (const char *words, wordexp_t *pwordexp, int flags)
+     {
+       /* Minimal implementation of WRDE_REUSE for now */
+       wordfree (pwordexp);
++      old_word.we_wordc = 0;
+       old_word.we_wordv = NULL;
++      pwordexp->we_wordc = 0;
+     }
+ 
+   if ((flags & WRDE_APPEND) == 0)
+-- 
+2.52.0
+

--- a/meta-core/recipes-core/glibc/glibc_2.31%.bbappend
+++ b/meta-core/recipes-core/glibc/glibc_2.31%.bbappend
@@ -11,4 +11,5 @@ SRC_URI_append = " \
     file://CVE-2024-33601-CVE-2024-33602.patch \
     file://CVE-2026-0915.patch \
     file://CVE-2026-0861.patch \
+    file://CVE-2025-15281.patch \
     "


### PR DESCRIPTION
Backports the fix for CVE-2025-15281 from
https://sourceware.org/git/?p=glibc.git;a=commit;h=28eb5caf895ced5d895cb02757e109004a2d33e5