### PR TITLE
Enable image builds with automated testing

### DIFF
--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -7,6 +7,11 @@ on:  # yamllint disable-line rule:truthy
         description: 'The Yocto branch that is intended to be built'
         required: true
         type: string
+      target-image:
+        description: 'The image that is intended to be built'
+        default: 'core-image-minimal'
+        required: false
+        type: string
       only-build-modified:
         description: 'If true, bitbake will only build the recipes that are affected by the PR'
         required: true
@@ -114,13 +119,15 @@ jobs:
 
           # Add CI configurations
           echo "require $GITHUB_WORKSPACE/meta-lts-collab/conf/ci.conf" >> conf/auto.conf
+          printf "IMAGE_INSTALL += \"%s\"\n" \
+            "${{ steps.targets.outputs.build_targets }}" >> conf/auto.conf
 
           # Run bitbake
           extra_args=""
           if [ "${{ inputs.parse-only }}" = "true" ]; then
             extra_args="--parse-only"
           fi
-          bitbake $extra_args ${{ steps.targets.outputs.build_targets }}
+          bitbake $extra_args ${{ inputs.target-image }}
 
       - name: Save downloads and sstate
         if: ${{ inputs.save-cache && steps.targets.outputs.build_targets != '' }}

--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -24,6 +24,11 @@ on:  # yamllint disable-line rule:truthy
         description: 'The runner to execute this workfow with'
         required: true
         type: string
+      run-tests:
+        description: 'If true, runs the testimage tests after building'
+        default: false
+        required: false
+        type: boolean
       save-cache:
         description: 'Saves the download and sstate cache after the build finishes'
         default: false
@@ -128,6 +133,23 @@ jobs:
             extra_args="--parse-only"
           fi
           bitbake $extra_args ${{ inputs.target-image }}
+
+      - name: Enable KVM group perms
+        if: ${{ inputs.run-tests && steps.targets.outputs.build_targets != '' }}
+        run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | \
+              sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+
+      - name: Run tests
+        if: ${{ inputs.run-tests && steps.targets.outputs.build_targets != '' }}
+        run: |
+          # Source build environment
+          source poky/oe-init-build-env
+
+          # Run tests
+          bitbake -c testimage ${{ inputs.target-image }}
 
       - name: Save downloads and sstate
         if: ${{ inputs.save-cache && steps.targets.outputs.build_targets != '' }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,11 +24,12 @@ jobs:
       use-cache: false
 
   build:
-    name: 'Build recipes'
+    name: 'Build and test recipes'
     needs: parse
     uses: ./.github/workflows/bitbake-common.yml
     with:
       branch: ${{ github.base_ref }}
       only-build-modified: true
       parse-only: false
+      run-tests: true
       runner: yocto_build_host

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -38,6 +38,7 @@ jobs:
       branch: ${{ github.ref_name }}
       only-build-modified: false
       parse-only: false
+      run-tests: ${{ github.event_name == 'schedule' }}
       runner: yocto_build_host
       save-cache: true
       use-cache: ${{ github.event_name == 'push' }}

--- a/conf/ci.conf
+++ b/conf/ci.conf
@@ -1,4 +1,22 @@
 # Configurations to use when validating meta-lts-collab with CI
 
 # Required to build libpam
-DISTRO_FEATURES:append = " pam"
+DISTRO_FEATURES_append = " pam"
+
+# Enables ptest
+DISTRO_FEATURES_append = " ptest"
+EXTRA_IMAGE_FEATURES_append = " ssh-server-openssh ptest-pkgs"
+IMAGE_INSTALL_append = " ptest-runner"
+
+# Enable automated testing
+IMAGE_CLASSES += "testimage"
+TEST_TARGET = "qemu"
+TEST_SUITES = "ping ssh ptest"
+
+# do_testimage configuration
+TEST_RUNQEMUPARAMS += "kvm nographic slirp snapshot"
+TEST_QEMUPARAMS += "-smp 8"
+TEST_SERVER_IP = "127.0.0.1"
+QB_CPU_KVM = "-cpu host"
+QB_MEM = "-m 16384"
+QEMU_USE_SLIRP = "1"

--- a/meta-core/recipes-graphics/wayland/wayland_1.18.0.bbappend
+++ b/meta-core/recipes-graphics/wayland/wayland_1.18.0.bbappend
@@ -1,0 +1,3 @@
+INSANE_SKIP:${PN}-ptest:append = " dev-deps"
+
+RDEPENDS_${PN}-ptest += "${PN}-dev"


### PR DESCRIPTION
Currently, we only validate that changes do not affect buildability. However, CI has been unable to check for any runtime regressions that could be caused by contributions to meta-lts-collab.

This set of patches changes the current build method where the targeted recipes are not directly built with do_build (e.g., `bitbake target-recipe(s)`) and instead the targeted recipes are added to a core-image-minimal (by default) image via IMAGE_INSTALL in auto.conf. The ci.conf config file has also been updated with the configurations to allow ptests to be enabled for all packages included in the image. Additional configurations also set up the proper configurations for do_testimage, which runs the tests with QEMU.

There's a little more vetting likely necessary before this merges. I'm not sure if kvm acceleration can be used on github runners, some sort of acceleration will likely be necessary. Current testing on my machine shows that running ptests with all affected recipes by this layer likely takes over an hour (local test is still going 50 minutes in) even with 16G of memory and kvm acceleration. I could try adding more cores, but it doesn't seem like ptests can be parallelized at all (maybe individual tests can parallelize themselves?)

Mostly pushing this up so others can check it out and see if we want to more forward with more enhanced testing.