### PR TITLE
core: curl: Fix patch for CVE-2025-14524

### DIFF
--- a/meta-core/recipes-support/curl/curl/CVE-2025-14524.patch
+++ b/meta-core/recipes-support/curl/curl/CVE-2025-14524.patch
@@ -10,8 +10,8 @@ CVE: CVE-2025-14524
 Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
 
 ---
- lib/curl_sasl.c | 8 ++++++--
- 1 file changed, 6 insertions(+), 2 deletions(-)
+ lib/curl_sasl.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/lib/curl_sasl.c b/lib/curl_sasl.c
 index 8c1c86623d..005b3c3ca9 100644
@@ -28,17 +28,6 @@ index 8c1c86623d..005b3c3ca9 100644
  
    sasl->force_ir = force_ir;    /* Latch for future use */
    sasl->authused = 0;           /* No mechanism used yet */
-@@ -432,7 +434,9 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct connectdata *conn,
-   char *serverdata;
- #endif
-   size_t len = 0;
--  const char *oauth_bearer = data->set.str[STRING_BEARER];
-+  const char *oauth_bearer =
-+    (!data->state.this_is_a_follow || data->set.allow_auth_to_other_hosts) ?
-+    data->set.str[STRING_BEARER] : NULL;
- 
-   *progress = SASL_INPROGRESS;
- 
 -- 
 2.52.0
 


### PR DESCRIPTION
Fixes the patch for CVE-2025-14524 by only keeping the modification made to Curl_sasl_start. The original patch modified the use of STRING_BEARER in more locations than what was in the original upstream patch on https://github.com/curl/curl/commit/1a822275d333dc6da6043497160fd04c8fa48640