### PR TITLE
core: libpng: Backport fix for CVE-2026-25646

### DIFF
--- a/meta-core/recipes-multimedia/libpng/libpng/CVE-2026-25646.patch
+++ b/meta-core/recipes-multimedia/libpng/libpng/CVE-2026-25646.patch
@@ -1,0 +1,64 @@
+From 51a61aae36bfed3abcde4c0a6529bfddf497f406 Mon Sep 17 00:00:00 2001
+From: Cosmin Truta <ctruta@gmail.com>
+Date: Fri, 6 Feb 2026 19:11:54 +0200
+Subject: [PATCH] Fix a heap buffer overflow in `png_set_quantize`
+
+The color distance hash table stored the current palette indices, but
+the color-pruning loop assumed the original indices. When colors were
+eliminated and indices changed, the stored indices became stale. This
+caused the loop bound `max_d` to grow past the 769-element hash array.
+
+The fix consists in storing the original indices via `palette_to_index`
+to match the pruning loop's expectations.
+
+Reported-by: Joshua Inscoe <pwnalone@users.noreply.github.com>
+Co-authored-by: Joshua Inscoe <pwnalone@users.noreply.github.com>
+Signed-off-by: Cosmin Truta <ctruta@gmail.com>
+
+CVE: CVE-2026-25646
+Upstream-Status: Backport [https://github.com/pnggroup/libpng/commit/01d03b8453eb30ade759cd45c707e5a1c7277d88]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ AUTHORS    | 1 +
+ pngrtran.c | 6 +++---
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/AUTHORS b/AUTHORS
+index 79a3d1036..f4e4c9d72 100644
+--- a/AUTHORS
++++ b/AUTHORS
+@@ -14,6 +14,7 @@ Authors, for copyright and licensing purposes.
+  * Guy Eric Schalnat
+  * James Yu
+  * John Bowler
++ * Joshua Inscoe
+  * Kevin Bracey
+  * Magnus Holmgren
+  * Mandar Sahastrabuddhe
+diff --git a/pngrtran.c b/pngrtran.c
+index 18884ce5b..b6e38a7ea 100644
+--- a/pngrtran.c
++++ b/pngrtran.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngrtran.c - transforms the data in a row for PNG readers
+  *
+- * Copyright (c) 2018-2019 Cosmin Truta
++ * Copyright (c) 2018-2026 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -647,8 +647,8 @@ png_set_quantize(png_structrp png_ptr, png_colorp palette,
+                          break;
+ 
+                      t->next = hash[d];
+-                     t->left = (png_byte)i;
+-                     t->right = (png_byte)j;
++                     t->left = png_ptr->palette_to_index[i];
++                     t->right = png_ptr->palette_to_index[j];
+                      hash[d] = t;
+                   }
+                }
+-- 
+2.53.0
+

--- a/meta-core/recipes-multimedia/libpng/libpng_1.6.37.bbappend
+++ b/meta-core/recipes-multimedia/libpng/libpng_1.6.37.bbappend
@@ -9,4 +9,5 @@ SRC_URI_append = " \
     file://CVE-2025-66293-01.patch \
     file://CVE-2025-66293-02.patch \
     file://CVE-2026-22801.patch \
+    file://CVE-2026-25646.patch \
     "


### PR DESCRIPTION
Backports the fix for CVE-2026-25646 from
https://github.com/pnggroup/libpng/commit/01d03b8453eb30ade759cd45c707e5a1c7277d88