### PR TITLE
core: zlib: ignore CVE-2026-22184

### DIFF
--- a/meta-core/recipes-core/zlib/zlib_1.2.11.bbappend
+++ b/meta-core/recipes-core/zlib/zlib_1.2.11.bbappend
@@ -1,0 +1,3 @@
+# not-applicable-config:
+# vulnerable file is not compiled
+CVE_CHECK_WHITELIST += "CVE-2026-22184"


### PR DESCRIPTION
CVE-2026-22184 is not compiled in zlib by default and can be ignored.