### PR TITLE
core: busybox: Fix CVE-2025-60876

### DIFF
--- a/meta-core/recipes-core/busybox/busybox/CVE-2025-60876.patch
+++ b/meta-core/recipes-core/busybox/busybox/CVE-2025-60876.patch
@@ -1,0 +1,51 @@
+From: Radoslav Kolev <radoslav.kolev@suse.com>
+Date: Fri, 21 Nov 2025 11:21:18 +0200
+Subject: wget: don't allow control characters or spaces in the URL
+Bug-Debian: https://bugs.debian.org/1120795
+
+Fixes CVE-2025-60876 malicious URL can be used to inject
+HTTP headers in the request.
+
+Signed-off-by: Radoslav Kolev <radoslav.kolev@suse.com>
+Reviewed-by: Emmanuel Deloget <logout@free.fr>
+
+Upstream-Status: Submitted [https://lists.busybox.net/pipermail/busybox/2025-November/091840.html]
+
+CVE: CVE-2025-60876
+
+Signed-off-by: Livin Sunny <livinsunny519@gmail.com>
+---
+
+[Modification to the original patch]
+
+This patch is based on the original BusyBox patch by Radoslav Kolev.
+The upstream patch uses the bb_simple_error_msg_and_die API, which is available
+in the latest BusyBox versions. This version uses bb_error_msg_and_die instead
+for compatibility with older BusyBox releases.
+
+
+ networking/wget.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/networking/wget.c b/networking/wget.c
+index ec3767793..fa555427b 100644
+--- a/networking/wget.c
++++ b/networking/wget.c
+@@ -536,6 +536,15 @@ static void parse_url(const char *src_url, struct host_info *h)
+ {
+	char *url, *p, *sp;
+
++	/* Fix for CVE-2025-60876 - don't allow control characters or spaces in the URL */
++	/* otherwise a malicious URL can be used to inject HTTP headers in the request */
++	const unsigned char *u = (void *) src_url;
++	while (*u) {
++		if (*u <= ' ')
++			bb_error_msg_and_die("Unencoded control character found in the URL!");
++		u++;
++	}
++
+	free(h->allocated);
+	h->allocated = url = xstrdup(src_url);
+
+--
+2.47.3

--- a/meta-core/recipes-core/busybox/busybox_1.31.1.bbappend
+++ b/meta-core/recipes-core/busybox/busybox_1.31.1.bbappend
@@ -3,4 +3,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI_append = " \
     file://CVE-2025-46394-01.patch \
     file://CVE-2025-46394-02.patch \
+    file://CVE-2025-60876.patch \
 "


### PR DESCRIPTION
This addresses CVE-2025-60876[1], which allows malicious URLs to inject HTTP headers. It has been accepted by Debian[2] and is tracked here [4]. The upstream fix has been submitted [3] and is pending merge.

[1] https://nvd.nist.gov/vuln/detail/CVE-2025-60876
[2] https://bugs.debian.org/1120795
[3] https://lists.busybox.net/pipermail/busybox/2025-November/091840.html
[4] https://security-tracker.debian.org/tracker/CVE-2025-60876

Upstream-Status: Submitted [https://lists.busybox.net/pipermail/busybox/2025-November/0918 40.html]