### PR TITLE
core: python3-jinja2: fix CVE ID

### DIFF
--- a/meta-core/recipes-devtools/python/python3-jinja2/CVE-2025-27516.patch
+++ b/meta-core/recipes-devtools/python/python3-jinja2/CVE-2025-27516.patch
@@ -5,7 +5,7 @@ Subject: attr filter uses env.getattr
 
 Origin: backport, https://github.com/pallets/jinja/commit/065334d1ee5b7210e1a0
 
-CVE: CVE-2025-37516
+CVE: CVE-2025-27516
 Upstream-Status: Backport [https://github.com/pallets/jinja/commit/065334d1ee5b7210e1a0]
 Signed-off-by: Colin Pinnell McAllister <colin.mcallister@garmin.com>
 ---

--- a/meta-core/recipes-devtools/python/python3-jinja2_2.11.3.bbappend
+++ b/meta-core/recipes-devtools/python/python3-jinja2_2.11.3.bbappend
@@ -3,5 +3,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI_append = " \
     file://CVE-2024-56326-01.patch \
     file://CVE-2024-56326-02.patch \
-    file://CVE-2025-37516.patch \
+    file://CVE-2025-27516.patch \
 "


### PR DESCRIPTION
Fixes typo where the wrong CVE ID was used for CVE-2025-27516.