### PR TITLE
meta-oe: nginx: add CVE_PRODUCT

### DIFF
--- a/meta-oe/recipes-httpd/nginx/nginx_1.17.8.bbappend
+++ b/meta-oe/recipes-httpd/nginx/nginx_1.17.8.bbappend
@@ -4,3 +4,5 @@ SRC_URI_append = " \
     file://0001-CVE-2022-41741-CVE-2022-41742.patch \
     file://CVE-2025-23419.patch \
     "
+
+CVE_PRODUCT = "nginx:nginx f5:nginx_open_source f5:nginx"


### PR DESCRIPTION
Nginx has used multiple CPEs over time. Sets CVE_PRODUCT to capture all vendor:product pairs.