### PR TITLE
ci: fix failing ptests

### DIFF
--- a/conf/ci.conf
+++ b/conf/ci.conf
@@ -20,3 +20,7 @@ TEST_SERVER_IP = "127.0.0.1"
 QB_CPU_KVM = "-cpu host"
 QB_MEM = "-m 16384"
 QEMU_USE_SLIRP = "1"
+
+# Ensure there is enough space to run tests
+IMAGE_OVERHEAD_FACTOR = "1.0"
+IMAGE_ROOTFS_EXTRA_SPACE = "1124288"


### PR DESCRIPTION
core-image-mininal as the test image does not have the proper amount of space to run tests. This change copies over a section from core-image-ptest to ci.conf to ensure enough extra space exists to run ptests.