### PR TITLE
core: libpng: Backport fix for CVE-2026-33636

### DIFF
--- a/meta-core/recipes-multimedia/libpng/libpng/CVE-2026-33636.patch
+++ b/meta-core/recipes-multimedia/libpng/libpng/CVE-2026-33636.patch
@@ -1,0 +1,98 @@
+From fe720896f7f834b7c46ccd0a16134ef48fc8d32c Mon Sep 17 00:00:00 2001
+From: Cosmin Truta <ctruta@gmail.com>
+Date: Sat, 21 Mar 2026 23:48:49 +0200
+Subject: [PATCH] fix(arm): Resolve out-of-bounds read/write in NEON palette
+ expansion
+
+Both `png_do_expand_palette_rgba8_neon` and
+`png_do_expand_palette_rgb8_neon` advanced in fixed-size chunks without
+guarding the final iteration, allowing out-of-bounds reads and writes
+when the row width is not a multiple of the chunk size.
+
+Restrict the NEON loop to full chunks only, remove the now-unnecessary
+post-loop adjustment, and undo the `*ddp` pre-adjustment before the
+pointer handoff to the scalar fallback.
+
+Reported-by: Amemoyoi <Amemoyoi@users.noreply.github.com>
+Co-authored-by: Amemoyoi <Amemoyoi@users.noreply.github.com>
+Signed-off-by: Cosmin Truta <ctruta@gmail.com>
+
+CVE: CVE-2026-33636
+Upstream-Status: Backport [https://github.com/pnggroup/libpng/commit/aba9f18eba870d14fb52c5ba5d73451349e339c3]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ arm/palette_neon_intrinsics.c | 29 +++++++++++++----------------
+ 1 file changed, 13 insertions(+), 16 deletions(-)
+
+diff --git a/arm/palette_neon_intrinsics.c b/arm/palette_neon_intrinsics.c
+index b4d1fd2ab..03e4f5953 100644
+--- a/arm/palette_neon_intrinsics.c
++++ b/arm/palette_neon_intrinsics.c
+@@ -1,7 +1,7 @@
+ 
+ /* palette_neon_intrinsics.c - NEON optimised palette expansion functions
+  *
+- * Copyright (c) 2018-2019 Cosmin Truta
++ * Copyright (c) 2018-2026 Cosmin Truta
+  * Copyright (c) 2017-2018 Arm Holdings. All rights reserved.
+  * Written by Richard Townsend <Richard.Townsend@arm.com>, February 2017.
+  *
+@@ -79,7 +79,7 @@ png_do_expand_palette_rgba8_neon(png_structrp png_ptr, png_row_infop row_info,
+     */
+    *ddp = *ddp - ((pixels_per_chunk * sizeof(png_uint_32)) - 1);
+ 
+-   for (i = 0; i < row_width; i += pixels_per_chunk)
++   for (i = 0; i + pixels_per_chunk <= row_width; i += pixels_per_chunk)
+    {
+       uint32x4_t cur;
+       png_bytep sp = *ssp - i, dp = *ddp - (i << 2);
+@@ -89,13 +89,12 @@ png_do_expand_palette_rgba8_neon(png_structrp png_ptr, png_row_infop row_info,
+       cur = vld1q_lane_u32(riffled_palette + *(sp - 0), cur, 3);
+       vst1q_u32((void *)dp, cur);
+    }
+-   if (i != row_width)
+-   {
+-      /* Remove the amount that wasn't processed. */
+-      i -= pixels_per_chunk;
+-   }
+ 
+-   /* Decrement output pointers. */
++   /* Undo the pre-adjustment of *ddp before the pointer handoff,
++    * so the scalar fallback in pngrtran.c receives a dp that points
++    * to the correct position.
++    */
++   *ddp = *ddp + (pixels_per_chunk * 4 - 1);
+    *ssp = *ssp - i;
+    *ddp = *ddp - (i << 2);
+    return i;
+@@ -119,7 +118,7 @@ png_do_expand_palette_rgb8_neon(png_structrp png_ptr, png_row_infop row_info,
+    /* Seeking this back by 8 pixels x 3 bytes. */
+    *ddp = *ddp - ((pixels_per_chunk * sizeof(png_color)) - 1);
+ 
+-   for (i = 0; i < row_width; i += pixels_per_chunk)
++   for (i = 0; i + pixels_per_chunk <= row_width; i += pixels_per_chunk)
+    {
+       uint8x8x3_t cur;
+       png_bytep sp = *ssp - i, dp = *ddp - ((i << 1) + i);
+@@ -134,13 +133,11 @@ png_do_expand_palette_rgb8_neon(png_structrp png_ptr, png_row_infop row_info,
+       vst3_u8((void *)dp, cur);
+    }
+ 
+-   if (i != row_width)
+-   {
+-      /* Remove the amount that wasn't processed. */
+-      i -= pixels_per_chunk;
+-   }
+-
+-   /* Decrement output pointers. */
++   /* Undo the pre-adjustment of *ddp before the pointer handoff,
++    * so the scalar fallback in pngrtran.c receives a dp that points
++    * to the correct position.
++    */
++   *ddp = *ddp + (pixels_per_chunk * 3 - 1);
+    *ssp = *ssp - i;
+    *ddp = *ddp - ((i << 1) + i);
+    return i;
+-- 
+2.54.0
+

--- a/meta-core/recipes-multimedia/libpng/libpng_1.6.37.bbappend
+++ b/meta-core/recipes-multimedia/libpng/libpng_1.6.37.bbappend
@@ -10,4 +10,5 @@ SRC_URI_append = " \
     file://CVE-2025-66293-02.patch \
     file://CVE-2026-22801.patch \
     file://CVE-2026-25646.patch \
+    file://CVE-2026-33636.patch \
     "


### PR DESCRIPTION
Backports the fix for CVE-2026-33636 from
https://github.com/pnggroup/libpng/commit/aba9f18eba870d14fb52c5ba5d73451349e339c3