### PR TITLE
kirkstone: backport OpenSSH CVE fixes from 10.3p1

### DIFF
--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35385.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35385.patch
@@ -1,0 +1,42 @@
+From 3a408407c94fd47a1edf6e685ff9ceee12dbcf2f Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:42:16 +0000
+Subject: [PATCH] upstream: when downloading files as root in legacy (-O) mode
+ and
+
+without the -p (preserve modes) flag set, clear setuid/setgid bits from
+downloaded files as one might expect.
+
+AFAIK this bug dates back to the original Berkeley rcp program.
+
+Reported by Christos Papakonstantinou of Cantina and Spearbit.
+
+OpenBSD-Commit-ID: 49e902fca8dd933a92a9b547ab31f63e86729fa1
+
+CVE: CVE-2026-35385
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/487e8ac146f7d6616f65c125d5edb210519b833a]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ scp.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/scp.c b/scp.c
+index 519bffa1be1e..2e37da4a3ecf 100644
+--- a/scp.c
++++ b/scp.c
+@@ -1606,8 +1606,10 @@ sink(int argc, char **argv, const char *src)
+ 
+ 	setimes = targisdir = 0;
+ 	mask = umask(0);
+-	if (!pflag)
++	if (!pflag) {
++		mask |= 07000;
+ 		(void) umask(mask);
++	}
+ 	if (argc != 1) {
+ 		run_err("ambiguous target");
+ 		exit(1);
+-- 
+2.54.0
+

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386.patch
@@ -1,0 +1,58 @@
+From d2eb17f10284ee542cddd592453cb336c0f11e80 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:50:55 +0000
+Subject: [PATCH] upstream: move username validity check for usernames
+ specified on
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+the commandline to earlier in main(), specifically before some contexts where
+a username with shell characters might be expanded by a %u directive in
+ssh_config.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We continue to recommend against using untrusted input on
+the SSH commandline. Mitigations like this are not 100%
+guarantees of safety because we can't control every
+combination of user shell and configuration where they are
+used.
+
+Reported by Florian Kohnhäuser
+
+OpenBSD-Commit-ID: 25ef72223f5ccf1c38d307ae77c23c03f59acc55
+
+CVE: CVE-2026-35386
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/76685c9b09a66435cd2ad8373246adf1c53976d3]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ ssh.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/ssh.c b/ssh.c
+index 8f3c335744d2..cf7d26bb322c 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -1139,10 +1139,14 @@ main(int ac, char **av)
+ 	if (!host)
+ 		usage();
+ 
+-	if (!valid_hostname(host))
+-		fatal("hostname contains invalid characters");
++	/*
++	 * Validate commandline-specified values that end up in %tokens
++	 * before they are used in config parsing.
++	 */
+ 	if (options.user != NULL && !valid_ruser(options.user))
+ 		fatal("remote username contains invalid characters");
++	if (!valid_hostname(host))
++		fatal("hostname contains invalid characters");
+ 	host_arg = xstrdup(host);
+ 
+ 	/* Initialize the command to execute on remote host. */
+-- 
+2.54.0
+

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35387.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35387.patch
@@ -1,0 +1,166 @@
+From 854506cb3294f866bbbf9dbc7b1740cb24723d5b Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:48:13 +0000
+Subject: [PATCH] upstream: correctly match ECDSA signature algorithms against
+
+algorithm allowlists: HostKeyAlgorithms, PubkeyAcceptedAlgorithms and
+HostbasedAcceptedAlgorithms.
+
+Previously, if any ECDSA type (say "ecdsa-sha2-nistp521") was
+present in one of these lists, then all ECDSA algorithms would
+be permitted.
+
+Reported by Christos Papakonstantinou of Cantina and Spearbit.
+
+OpenBSD-Commit-ID: c790e2687c35989ae34a00e709be935c55b16a86
+
+CVE: CVE-2026-35387
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/fd1c7e131f331942d20f42f31e79912d570081fa]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ auth2-hostbased.c |  7 ++++---
+ auth2-pubkey.c    | 30 +++++++++++++++++-------------
+ sshconnect2.c     | 26 +++++++++++++++++---------
+ 3 files changed, 38 insertions(+), 25 deletions(-)
+
+diff --git a/auth2-hostbased.c b/auth2-hostbased.c
+index 36b9d2f5b0e5..6882a4f0fcef 100644
+--- a/auth2-hostbased.c
++++ b/auth2-hostbased.c
+@@ -96,9 +96,10 @@ userauth_hostbased(struct ssh *ssh, const char *method)
+ 		error_f("cannot decode key: %s", pkalg);
+ 		goto done;
+ 	}
+-	if (key->type != pktype) {
+-		error_f("type mismatch for decoded key "
+-		    "(received %d, expected %d)", key->type, pktype);
++	if (key->type != pktype || (sshkey_type_plain(pktype) == KEY_ECDSA &&
++	    sshkey_ecdsa_nid_from_name(pkalg) != key->ecdsa_nid)) {
++		error_f("key type mismatch for decoded key "
++		    "(received %s, expected %s)", sshkey_ssh_name(key), pkalg);
+ 		goto done;
+ 	}
+ 	if (sshkey_type_plain(key->type) == KEY_RSA &&
+diff --git a/auth2-pubkey.c b/auth2-pubkey.c
+index 9c2298fc887d..db32c29b1d45 100644
+--- a/auth2-pubkey.c
++++ b/auth2-pubkey.c
+@@ -150,9 +150,10 @@ userauth_pubkey(struct ssh *ssh, const char *method)
+ 		error_f("cannot decode key: %s", pkalg);
+ 		goto done;
+ 	}
+-	if (key->type != pktype) {
+-		error_f("type mismatch for decoded key "
+-		    "(received %d, expected %d)", key->type, pktype);
++	if (key->type != pktype || (sshkey_type_plain(pktype) == KEY_ECDSA &&
++	    sshkey_ecdsa_nid_from_name(pkalg) != key->ecdsa_nid)) {
++		error_f("key type mismatch for decoded key "
++		    "(received %s, expected %s)", sshkey_ssh_name(key), pkalg);
+ 		goto done;
+ 	}
+ 	if (sshkey_type_plain(key->type) == KEY_RSA &&
+@@ -319,20 +320,23 @@ done:
+ static int
+ match_principals_option(const char *principal_list, struct sshkey_cert *cert)
+ {
+-	char *result;
++	char *list, *olist, *entry;
+ 	u_int i;
+ 
+-	/* XXX percent_expand() sequences for authorized_principals? */
+-
+-	for (i = 0; i < cert->nprincipals; i++) {
+-		if ((result = match_list(cert->principals[i],
+-		    principal_list, NULL)) != NULL) {
+-			debug3("matched principal from key options \"%.100s\"",
+-			    result);
+-			free(result);
+-			return 1;
++	olist = list = xstrdup(principal_list);
++	for (;;) {
++		if ((entry = strsep(&list, ",")) == NULL || *entry == '\0')
++			break;
++		for (i = 0; i < cert->nprincipals; i++) {
++			if (strcmp(entry, cert->principals[i]) == 0) {
++				debug3("matched principal from key i"
++				    "options \"%.100s\"", entry);
++				free(olist);
++				return 1;
++			}
+ 		}
+ 	}
++	free(olist);
+ 	return 0;
+ }
+ 
+diff --git a/sshconnect2.c b/sshconnect2.c
+index 6cfae2af086a..491ec5fcecab 100644
+--- a/sshconnect2.c
++++ b/sshconnect2.c
+@@ -92,10 +92,15 @@ extern Options options;
+ static char *xxx_host;
+ static struct sockaddr *xxx_hostaddr;
+ static const struct ssh_conn_info *xxx_conn_info;
++static int key_type_allowed(struct sshkey *, const char *);
+ 
+ static int
+ verify_host_key_callback(struct sshkey *hostkey, struct ssh *ssh)
+ {
++	if (!key_type_allowed(hostkey, options.hostkeyalgorithms)) {
++		fatal("Server host key %s not in HostKeyAlgorithms",
++		    sshkey_ssh_name(hostkey));
++	}
+ 	if (verify_host_key(xxx_host, xxx_hostaddr, hostkey,
+ 	    xxx_conn_info) != 0)
+ 		fatal("Host key verification failed.");
+@@ -1615,34 +1620,37 @@ load_identity_file(Identity *id)
+ }
+ 
+ static int
+-key_type_allowed_by_config(struct sshkey *key)
++key_type_allowed(struct sshkey *key, const char *allowlist)
+ {
+-	if (match_pattern_list(sshkey_ssh_name(key),
+-	    options.pubkey_accepted_algos, 0) == 1)
++	if (match_pattern_list(sshkey_ssh_name(key), allowlist, 0) == 1)
+ 		return 1;
+ 
+ 	/* RSA keys/certs might be allowed by alternate signature types */
+ 	switch (key->type) {
+ 	case KEY_RSA:
+-		if (match_pattern_list("rsa-sha2-512",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		if (match_pattern_list("rsa-sha2-512", allowlist, 0) == 1)
+ 			return 1;
+-		if (match_pattern_list("rsa-sha2-256",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		if (match_pattern_list("rsa-sha2-256", allowlist, 0) == 1)
+ 			return 1;
+ 		break;
+ 	case KEY_RSA_CERT:
+ 		if (match_pattern_list("rsa-sha2-512-cert-v01@openssh.com",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		    allowlist, 0) == 1)
+ 			return 1;
+ 		if (match_pattern_list("rsa-sha2-256-cert-v01@openssh.com",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		    allowlist, 0) == 1)
+ 			return 1;
+ 		break;
+ 	}
+ 	return 0;
+ }
+ 
++static int
++key_type_allowed_by_config(struct sshkey *key)
++{
++	return key_type_allowed(key, options.pubkey_accepted_algos);
++}
++
+ /* obtain a list of keys from the agent */
+ static int
+ get_agent_identities(struct ssh *ssh, int *agent_fdp,
+-- 
+2.54.0
+

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35388.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35388.patch
@@ -1,0 +1,42 @@
+From 4d246bb8b963a1dbc20257190e01072490b42c06 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:39:57 +0000
+Subject: [PATCH] upstream: add missing askpass check when using
+
+ControlMaster=ask/autoask and "ssh -O proxy ..."; reported by Michalis
+Vasileiadis
+
+OpenBSD-Commit-ID: 8dd7b9b96534e9a8726916b96d36bed466d3836a
+
+CVE: CVE-2026-35388
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/c805b97b67c774e0bf922ffb29dfbcda9d7b5add]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ mux.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/mux.c b/mux.c
+index 176f035c86f5..41f044a238da 100644
+--- a/mux.c
++++ b/mux.c
+@@ -1122,6 +1122,16 @@ mux_master_process_proxy(struct ssh *ssh, u_int rid,
+ 
+ 	debug_f("channel %d: proxy request", c->self);
+ 
++	if (options.control_master == SSHCTL_MASTER_ASK ||
++	    options.control_master == SSHCTL_MASTER_AUTO_ASK) {
++		if (!ask_permission("Allow multiplex proxy connection?")) {
++			debug2_f("proxy refused by user");
++			reply_error(reply, MUX_S_PERMISSION_DENIED, rid,
++			    "Permission denied");
++			return 0;
++		}
++	}
++
+ 	c->mux_rcb = channel_proxy_downstream;
+ 	if ((r = sshbuf_put_u32(reply, MUX_S_PROXY)) != 0 ||
+ 	    (r = sshbuf_put_u32(reply, rid)) != 0)
+-- 
+2.54.0
+

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35414.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35414.patch
@@ -1,0 +1,344 @@
+From c4fe0390b5e16fb1a28c267e7eea5d4dacd9b7d8 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Mon, 22 Dec 2025 01:49:03 +0000
+Subject: [PATCH] upstream: When certificate support was added to OpenSSH,
+
+certificates were originally specified to represent any principal if the
+principals list was empty.
+
+This was, in retrospect, a mistake as it created a fail-open
+situation if a CA could be convinced to accidentally sign a
+certificate with no principals. This actually happened in a 3rd-
+party CA product (CVE-2024-7594).
+
+Somewhat fortunately, the main pathway for using certificates in
+sshd (TrustedUserCAKeys) never supported empty-principals
+certificates, so the blast radius of such mistakes was
+substantially reduced.
+
+This change removes this footcannon and requires all certificates
+include principals sections. It also fixes interpretation of
+wildcard principals, and properly enables them for host
+certificates only.
+
+This is a behaviour change that will permanently break uses of
+certificates with empty principals sections.
+
+ok markus@
+
+OpenBSD-Commit-ID: 0a901f03c567c100724a492cf91e02939904712e
+
+CVE: CVE-2026-35414
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/5166b6cbf2b6103117a79f90a68068e89e02bf66]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ auth2-hostbased.c |  4 ++--
+ auth2-pubkey.c    |  4 ++--
+ ssh-agent.c       |  2 +-
+ ssh-keygen.1      | 30 +++++++++++++++++++-------
+ ssh-keygen.c      |  9 ++++++++
+ sshconnect.c      |  2 +-
+ sshkey.c          | 55 ++++++++++++++++++++++-------------------------
+ sshkey.h          |  6 +++---
+ sshsig.c          |  6 +++---
+ 9 files changed, 69 insertions(+), 49 deletions(-)
+
+diff --git a/auth2-hostbased.c b/auth2-hostbased.c
+index 6882a4f0fcef..0e0a3cba0cf9 100644
+--- a/auth2-hostbased.c
++++ b/auth2-hostbased.c
+@@ -213,8 +213,8 @@ hostbased_key_allowed(struct ssh *ssh, struct passwd *pw,
+ 	}
+ 	debug2_f("access allowed by auth_rhosts2");
+ 
+-	if (sshkey_is_cert(key) &&
+-	    sshkey_cert_check_authority_now(key, 1, 0, 0, lookup, &reason)) {
++	if (sshkey_is_cert(key) && sshkey_cert_check_host(key, lookup,
++	     options.ca_sign_algorithms, &reason) != 0) {
+ 		error("%s", reason);
+ 		auth_debug_add("%s", reason);
+ 		return 0;
+diff --git a/auth2-pubkey.c b/auth2-pubkey.c
+index db32c29b1d45..4cafcbd0e74c 100644
+--- a/auth2-pubkey.c
++++ b/auth2-pubkey.c
+@@ -701,7 +701,7 @@ check_authkey_line(struct ssh *ssh, struct passwd *pw, struct sshkey *key,
+ 		reason = "Certificate does not contain an authorized principal";
+ 		goto fail_reason;
+ 	}
+-	if (sshkey_cert_check_authority_now(key, 0, 0, 0,
++	if (sshkey_cert_check_authority_now(key, 0, 0,
+ 	    keyopts->cert_principals == NULL ? pw->pw_name : NULL,
+ 	    &reason) != 0)
+ 		goto fail_reason;
+@@ -824,7 +824,7 @@ user_cert_trusted_ca(struct ssh *ssh, struct passwd *pw, struct sshkey *key,
+ 	}
+ 	if (use_authorized_principals && principals_opts == NULL)
+ 		fatal_f("internal error: missing principals_opts");
+-	if (sshkey_cert_check_authority_now(key, 0, 1, 0,
++	if (sshkey_cert_check_authority_now(key, 0, 0,
+ 	    use_authorized_principals ? NULL : pw->pw_name, &reason) != 0)
+ 		goto fail_reason;
+ 
+diff --git a/ssh-agent.c b/ssh-agent.c
+index 6382ef4f4177..6fb558f615bf 100644
+--- a/ssh-agent.c
++++ b/ssh-agent.c
+@@ -391,7 +391,7 @@ match_key_hop(const char *tag, const struct sshkey *key,
+ 			return -1; /* shouldn't happen */
+ 		if (!sshkey_equal(key->cert->signature_key, dch->keys[i]))
+ 			continue;
+-		if (sshkey_cert_check_host(key, hostname, 1,
++		if (sshkey_cert_check_host(key, hostname,
+ 		    SSH_ALLOWED_CA_SIGALGS, &reason) != 0) {
+ 			debug_f("cert %s / hostname %s rejected: %s",
+ 			    key->cert->key_id, hostname, reason);
+diff --git a/ssh-keygen.1 b/ssh-keygen.1
+index 59b7f23a1fa5..a5b5ec9a3f26 100644
+--- a/ssh-keygen.1
++++ b/ssh-keygen.1
+@@ -897,15 +897,29 @@ User certificates authenticate users to servers, whereas host certificates
+ authenticate server hosts to users.
+ To generate a user certificate:
+ .Pp
+-.Dl $ ssh-keygen -s /path/to/ca_key -I key_id /path/to/user_key.pub
++.Dl $ ssh-keygen -s /path/to/ca_key -I id -n user \e
++.Dl \ \ \ \ \ \ /path/to/user_key.pub
+ .Pp
+ The resultant certificate will be placed in
+ .Pa /path/to/user_key-cert.pub .
++The argument to
++.Fl I
++is a key identifier that will be used in logs and may be used to revoke
++keys.
++The argument to
++.Fl n
++is one or more (comma-separated) principals, typically usernames, that
++the certificate represents.
+ A host certificate requires the
+ .Fl h
+ option:
+ .Pp
+-.Dl $ ssh-keygen -s /path/to/ca_key -I key_id -h /path/to/host_key.pub
++.Dl $ ssh-keygen -s /path/to/ca_key -I id -h -n foo.example.org \e
++.Dl \ \ \ \ \ \ /path/to/host_key.pub
++.Pp
++For host certificates, the principals specified using the
++.Fl n
++argument are hostnames and may contain wildcard characters.
+ .Pp
+ The host certificate will be output to
+ .Pa /path/to/host_key-cert.pub .
+@@ -917,7 +931,8 @@ and identifying the CA key by providing its public half as an argument
+ to
+ .Fl s :
+ .Pp
+-.Dl $ ssh-keygen -s ca_key.pub -D libpkcs11.so -I key_id user_key.pub
++.Dl $ ssh-keygen -s ca_key.pub -D libpkcs11.so -I id -n user \e
++.Dl \ \ \ \ \ \ user_key.pub
+ .Pp
+ Similarly, it is possible for the CA key to be hosted in a
+ .Xr ssh-agent 1 .
+@@ -925,20 +940,19 @@ This is indicated by the
+ .Fl U
+ flag and, again, the CA key must be identified by its public half.
+ .Pp
+-.Dl $ ssh-keygen -Us ca_key.pub -I key_id user_key.pub
++.Dl $ ssh-keygen -Us ca_key.pub -I id -n user user_key.pub
+ .Pp
+ In all cases,
+ .Ar key_id
+ is a "key identifier" that is logged by the server when the certificate
+ is used for authentication.
+ .Pp
+-Certificates may be limited to be valid for a set of principal (user/host)
++Certificates are limited to be valid for a set of principal (user/host)
+ names.
+-By default, generated certificates are valid for all users or hosts.
+ To generate a certificate for a specified set of principals:
+ .Pp
+-.Dl $ ssh-keygen -s ca_key -I key_id -n user1,user2 user_key.pub
+-.Dl "$ ssh-keygen -s ca_key -I key_id -h -n host.domain host_key.pub"
++.Dl $ ssh-keygen -s ca_key -I id -n user1,user2 user_key.pub
++.Dl $ ssh-keygen -s ca_key -I id -h -n host.domain host_key.pub
+ .Pp
+ Additional limitations on the validity and use of user certificates may
+ be specified through certificate options.
+diff --git a/ssh-keygen.c b/ssh-keygen.c
+index d4b7f4dcf800..c2c1629b88be 100644
+--- a/ssh-keygen.c
++++ b/ssh-keygen.c
+@@ -3607,6 +3607,15 @@ main(int argc, char **argv)
+ 	if (ca_key_path != NULL) {
+ 		if (cert_key_id == NULL)
+ 			fatal("Must specify key id (-I) when certifying");
++		if (cert_principals == NULL) {
++			/*
++			 * Ideally this would be a fatal(), but we need to
++			 * be able to generate such certificates for testing
++			 * even though they will be rejected.
++			 */
++			error("Warning: certificate will contain no "
++			    "principals (-n)");
++		}
+ 		for (i = 0; i < nopts; i++)
+ 			add_cert_option(opts[i]);
+ 		do_ca_sign(pw, ca_key_path, prefer_agent,
+diff --git a/sshconnect.c b/sshconnect.c
+index ebecc83747bb..732377e31655 100644
+--- a/sshconnect.c
++++ b/sshconnect.c
+@@ -1044,7 +1044,7 @@ check_host_key(char *hostname, const struct ssh_conn_info *cinfo,
+ 		if (want_cert) {
+ 			if (sshkey_cert_check_host(host_key,
+ 			    options.host_key_alias == NULL ?
+-			    hostname : options.host_key_alias, 0,
++			    hostname : options.host_key_alias,
+ 			    options.ca_sign_algorithms, &fail_reason) != 0) {
+ 				error("%s", fail_reason);
+ 				goto fail;
+diff --git a/sshkey.c b/sshkey.c
+index f1e92003b7e4..d57f6d550f4c 100644
+--- a/sshkey.c
++++ b/sshkey.c
+@@ -3105,8 +3105,8 @@ sshkey_certify(struct sshkey *k, struct sshkey *ca, const char *alg,
+ 
+ int
+ sshkey_cert_check_authority(const struct sshkey *k,
+-    int want_host, int require_principal, int wildcard_pattern,
+-    uint64_t verify_time, const char *name, const char **reason)
++    int want_host, int wildcard_pattern, uint64_t verify_time,
++    const char *name, const char **reason)
+ {
+ 	u_int i, principal_matches;
+ 
+@@ -3136,37 +3136,36 @@ sshkey_cert_check_authority(const struct sshkey *k,
+ 		return SSH_ERR_KEY_CERT_INVALID;
+ 	}
+ 	if (k->cert->nprincipals == 0) {
+-		if (require_principal) {
+-			*reason = "Certificate lacks principal list";
+-			return SSH_ERR_KEY_CERT_INVALID;
+-		}
+-	} else if (name != NULL) {
+-		principal_matches = 0;
+-		for (i = 0; i < k->cert->nprincipals; i++) {
+-			if (wildcard_pattern) {
+-				if (match_pattern(k->cert->principals[i],
+-				    name)) {
+-					principal_matches = 1;
+-					break;
+-				}
+-			} else if (strcmp(name, k->cert->principals[i]) == 0) {
++		*reason = "Certificate lacks principal list";
++		return SSH_ERR_KEY_CERT_INVALID;
++	}
++	if (name == NULL)
++		return 0; /* principal matching not requested */
++
++	principal_matches = 0;
++	for (i = 0; i < k->cert->nprincipals; i++) {
++		if (wildcard_pattern) {
++			if (match_pattern(name, k->cert->principals[i])) {
+ 				principal_matches = 1;
+ 				break;
+ 			}
++		} else if (strcmp(name, k->cert->principals[i]) == 0) {
++			principal_matches = 1;
++			break;
+ 		}
+-		if (!principal_matches) {
+-			*reason = "Certificate invalid: name is not a listed "
+-			    "principal";
+-			return SSH_ERR_KEY_CERT_INVALID;
+-		}
++	}
++	if (!principal_matches) {
++		*reason = "Certificate invalid: name is not a listed "
++		    "principal";
++		return SSH_ERR_KEY_CERT_INVALID;
+ 	}
+ 	return 0;
+ }
+ 
+ int
+ sshkey_cert_check_authority_now(const struct sshkey *k,
+-    int want_host, int require_principal, int wildcard_pattern,
+-    const char *name, const char **reason)
++    int want_host, int wildcard_pattern, const char *name,
++    const char **reason)
+ {
+ 	time_t now;
+ 
+@@ -3175,19 +3174,17 @@ sshkey_cert_check_authority_now(const struct sshkey *k,
+ 		*reason = "Certificate invalid: not yet valid";
+ 		return SSH_ERR_KEY_CERT_INVALID;
+ 	}
+-	return sshkey_cert_check_authority(k, want_host, require_principal,
+-	    wildcard_pattern, (uint64_t)now, name, reason);
++	return sshkey_cert_check_authority(k, want_host, wildcard_pattern,
++	    (uint64_t)now, name, reason);
+ }
+ 
+ int
+ sshkey_cert_check_host(const struct sshkey *key, const char *host,
+-    int wildcard_principals, const char *ca_sign_algorithms,
+-    const char **reason)
++    const char *ca_sign_algorithms, const char **reason)
+ {
+ 	int r;
+ 
+-	if ((r = sshkey_cert_check_authority_now(key, 1, 0, wildcard_principals,
+-	    host, reason)) != 0)
++	if ((r = sshkey_cert_check_authority_now(key, 1, 1, host, reason)) != 0)
+ 		return r;
+ 	if (sshbuf_len(key->cert->critical) != 0) {
+ 		*reason = "Certificate contains unsupported critical options";
+diff --git a/sshkey.h b/sshkey.h
+index 094815e00a2a..878a458d19e6 100644
+--- a/sshkey.h
++++ b/sshkey.h
+@@ -199,12 +199,12 @@ int	 sshkey_match_keyname_to_sigalgs(const char *, const char *);
+ int	 sshkey_to_certified(struct sshkey *);
+ int	 sshkey_drop_cert(struct sshkey *);
+ int	 sshkey_cert_copy(const struct sshkey *, struct sshkey *);
+-int	 sshkey_cert_check_authority(const struct sshkey *, int, int, int,
++int	 sshkey_cert_check_authority(const struct sshkey *, int, int,
+     uint64_t, const char *, const char **);
+-int	 sshkey_cert_check_authority_now(const struct sshkey *, int, int, int,
++int	 sshkey_cert_check_authority_now(const struct sshkey *, int, int,
+     const char *, const char **);
+ int	 sshkey_cert_check_host(const struct sshkey *, const char *,
+-    int , const char *, const char **);
++    const char *, const char **);
+ size_t	 sshkey_format_cert_validity(const struct sshkey_cert *,
+     char *, size_t) __attribute__((__bounded__(__string__, 2, 3)));
+ int	 sshkey_check_cert_sigtype(const struct sshkey *, const char *);
+diff --git a/sshsig.c b/sshsig.c
+index 76d7c213b0fb..e46edc54fd87 100644
+--- a/sshsig.c
++++ b/sshsig.c
+@@ -832,8 +832,8 @@ cert_filter_principals(const char *path, u_long linenum,
+ 
+ 	while ((cp = strsep(&principals, ",")) != NULL && *cp != '\0') {
+ 		/* Check certificate validity */
+-		if ((r = sshkey_cert_check_authority(cert, 0, 1, 0,
+-		    verify_time, NULL, &reason)) != 0) {
++		if ((r = sshkey_cert_check_authority(cert, 0, 0, verify_time,
++		    NULL, &reason)) != 0) {
+ 			debug("%s:%lu: principal \"%s\" not authorized: %s",
+ 			    path, linenum, cp, reason);
+ 			continue;
+@@ -898,7 +898,7 @@ check_allowed_keys_line(const char *path, u_long linenum, char *line,
+ 	    sshkey_equal_public(sign_key->cert->signature_key, found_key)) {
+ 		if (principal) {
+ 			/* Match certificate CA key with specified principal */
+-			if ((r = sshkey_cert_check_authority(sign_key, 0, 1, 0,
++			if ((r = sshkey_cert_check_authority(sign_key, 0, 0,
+ 			    verify_time, principal, &reason)) != 0) {
+ 				error("%s:%lu: certificate not authorized: %s",
+ 				    path, linenum, reason);
+-- 
+2.54.0
+

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -3,4 +3,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI:append = " \
     file://CVE-2026-35385.patch \
     file://CVE-2026-35386.patch \
+    file://CVE-2026-35387.patch \
 "

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI:append = " \
+    file://CVE-2026-35385.patch \
+"

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -5,4 +5,5 @@ SRC_URI:append = " \
     file://CVE-2026-35386.patch \
     file://CVE-2026-35387.patch \
     file://CVE-2026-35388.patch \
+    file://CVE-2026-35414.patch \
 "

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI:append = " \
     file://CVE-2026-35385.patch \
+    file://CVE-2026-35386.patch \
 "

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -4,4 +4,5 @@ SRC_URI:append = " \
     file://CVE-2026-35385.patch \
     file://CVE-2026-35386.patch \
     file://CVE-2026-35387.patch \
+    file://CVE-2026-35388.patch \
 "


### PR DESCRIPTION
Backport the OpenSSH security fixes from 10.3p1 for the following CVEs:

* CVE-2026-35385
* CVE-2026-35386
* CVE-2026-35387
* CVE-2026-35388
* CVE-2026-35414