### PR TITLE
core: openssl: Backport fix for CVE-2026-28387

### DIFF
--- a/meta-core/recipes-connectivity/openssl/openssl/CVE-2026-28387.patch
+++ b/meta-core/recipes-connectivity/openssl/openssl/CVE-2026-28387.patch
@@ -1,0 +1,37 @@
+From 038a364604f2ace72e971a293687b8c7dbdd145d Mon Sep 17 00:00:00 2001
+From: Alexandr Nedvedicky <sashan@openssl.org>
+Date: Tue, 3 Mar 2026 13:23:46 +0100
+Subject: [PATCH] dane_match_cert() should X509_free() on ->mcert instead of
+ OPENSSL_free()
+
+Fixes: 170b735820ac "DANE support for X509_verify_cert()"
+
+Reviewed-by: Eugene Syromiatnikov <esyr@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+MergeDate: Thu Mar  5 12:37:17 2026
+(Merged from https://github.com/openssl/openssl/pull/30250)
+
+(cherry picked from commit 8b5cd6a682f0f6e7b8bf55137137c567d1899c4a)
+
+CVE: CVE-2026-28387
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/ec03fa050b3346997ed9c5fef3d0e16ad7db8177]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ crypto/x509/x509_vfy.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crypto/x509/x509_vfy.c b/crypto/x509/x509_vfy.c
+index 66b532a..bc46ae8 100644
+--- a/crypto/x509/x509_vfy.c
++++ b/crypto/x509/x509_vfy.c
+@@ -2761,7 +2761,7 @@ static int dane_match(X509_STORE_CTX *ctx, X509 *cert, int depth)
+             if (matched || dane->mdpth < 0) {
+                 dane->mdpth = depth;
+                 dane->mtlsa = t;
+-                OPENSSL_free(dane->mcert);
++                X509_free(dane->mcert);
+                 dane->mcert = cert;
+                 X509_up_ref(cert);
+             }

--- a/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
+++ b/meta-core/recipes-connectivity/openssl/openssl_1.1.1w.bbappend
@@ -6,4 +6,5 @@ SRC_URI_append = " \
     file://CVE-2025-69419.patch \
     file://CVE-2025-69420.patch \
     file://CVE-2026-22795-CVE-2026-22796.patch \
+    file://CVE-2026-28387.patch \
     "


### PR DESCRIPTION
Backports the fix for CVE-2026-28387 from
https://github.com/openssl/openssl/commit/ec03fa050b3346997ed9c5fef3d0e16ad7db8177