### PR TITLE
ci: enable dependabot

### DIFF
--- a/.github/ci-requirements.txt
+++ b/.github/ci-requirements.txt
@@ -1,0 +1,3 @@
+oelint-adv==9.8.0
+ruff==0.14.5
+yamllint==1.37.1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/.github/"
+    schedule:
+      interval: "weekly"
+    target-branch: kirkstone

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -24,8 +24,8 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install ruff
-        run: pip install ruff==0.14.5
+      - name: Install tools
+        run: pip install -r .github/ci-requirements.txt
 
       - name: Run ruff check on scripts
         run: ruff check scripts
@@ -33,14 +33,8 @@ jobs:
       - name: Run ruff format on scripts
         run: ruff format scripts/
 
-      - name: Install yamllint
-        run: pip install yamllint==1.37.1
-
       - name: Run yamllint on workflows
         run: yamllint .github/workflows/
-
-      - name: Install oelint-adv
-        run: pip install oelint-adv==9.8.0
 
       - name: Run oelint-adv
         run: oelint-adv $(find -name '*.bb' -o -name '*.bbappend' -o -name '*.conf')


### PR DESCRIPTION
to enable automatic updates of the used tools for linting dependabot is introduced.
This service scans once a week for updates of any of the tools referenced in ci-requirements.txt, creating a PR for each update found.

Relates to #79