### PR TITLE
README: Add OpenSSF Best Pratices Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # meta-lts-collab
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13092/badge)](https://www.bestpractices.dev/projects/13092)
+
 ## Table of Contents
 
 1. [Purpose and Scope](#1-purpose-and-scope)


### PR DESCRIPTION
Adds badge to top of README.

Related to #80

(cherry picked from commit ec5a8f90d062f3ba2cca32cddd7406ba7c34dd40)