### PR TITLE
ci/dependabot: add dunfell for action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      internal: "weekly"
+      interval: "weekly"
     target-branch: kirkstone
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: dunfell
+


### PR DESCRIPTION
- correct the interval keyword for kirkstone
- add dunfell for github-action updates as well
- remove the version comments from the pipeline as they might not be applicable after an update