### PR TITLE
Fix version inline comments

### DIFF
--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -48,19 +48,19 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Clone meta-lts-collab
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           path: ${{ github.workspace }}/meta-lts-collab
 
       - name: Clone poky (${{ inputs.branch }})
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           repository: yoctoproject/poky
           ref: ${{ inputs.branch }}
           path: ${{ github.workspace }}/poky
 
       - name: Clone meta-oe (${{ inputs.branch }})
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           repository: openembedded/meta-openembedded
           ref: ${{ inputs.branch }}

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -17,7 +17,7 @@ jobs:
     name: 'Lint scripts & CI'
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
 
       - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
Ensures all actions have the full semver in the inline comment.

This should ensure that Dependabot actually updates all inline comments (See #88, #89, #91, and #95).