### PR TITLE
core: libsoup-2.4: Ignore CVE-2026-1536 and CVE-2026-3634

### DIFF
--- a/meta-core/recipes-support/libsoup/libsoup-2.4_2.74.2.bbappend
+++ b/meta-core/recipes-support/libsoup/libsoup-2.4_2.74.2.bbappend
@@ -1,0 +1,5 @@
+# CVE was reported against the common header workflow within the Libsoup 3 library.
+# Libsoup 2.4 does not differentiate between common and uncommon headers and has a
+# single header processing workflow which prevents CR/LF characters in header values
+# and names.
+CVE_CHECK_IGNORE += "CVE-2026-1536 CVE-2026-3634"


### PR DESCRIPTION
Ignore CVE-2026-1536 and CVE-2026-3634 as the CVE was reported against the common header workflow within the Libsoup 3 library. Libsoup 2.4 does not differentiate between common and uncommon headers and has a single header processing workflow which prevents CR/LF characters in header values and names.