### PR TITLE
core: libtiff: Backport fix for CVE-2025-61144

### DIFF
--- a/meta-core/recipes-multimedia/libtiff/tiff/CVE-2025-61144.patch
+++ b/meta-core/recipes-multimedia/libtiff/tiff/CVE-2025-61144.patch
@@ -1,0 +1,27 @@
+From 88cf9dbb48f6e172629795ecffae35d5052f68aa Mon Sep 17 00:00:00 2001
+From: Lee Howard <faxguy@howardsilvan.com>
+Date: Fri, 5 Sep 2025 21:46:03 +0000
+Subject: [PATCH] tiffcrop: avoid buffer overflow
+
+Fixes #740
+
+CVE: CVE-2025-61144
+Upstream-Status: Backport [https://gitlab.com/libtiff/libtiff/-/commit/88cf9dbb48f6e172629795ecffae35d5052f68aa]
+Signed-off-by: Peter Marko <peter.marko@siemens.com>
+---
+ tools/tiffcrop.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index c69e166..cc0bb63 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -3794,7 +3794,7 @@ combineSeparateSamplesBytes (unsigned char *srcbuffs[], unsigned char *out,
+     {
+     if ((dumpfile != NULL) && (level == 2))
+       {
+-      for (s = 0; s < spp; s++)
++      for (s = 0; (s < spp) && (s < MAX_SAMPLES); s++)
+         {
+         dump_info (dumpfile, format, "combineSeparateSamplesBytes","Input data, Sample %d", s);
+         dump_buffer(dumpfile, format, 1, cols, row, srcbuffs[s] + (row * src_rowsize));

--- a/meta-core/recipes-multimedia/libtiff/tiff_4.1.0.bbappend
+++ b/meta-core/recipes-multimedia/libtiff/tiff_4.1.0.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI_append = " \
+    file://CVE-2025-61144.patch \
+    "


### PR DESCRIPTION
Backports fix for CVE-2025-61144 from
https://gitlab.com/libtiff/libtiff/-/commit/88cf9dbb48f6e172629795ecffae35d5052f68aa