### PR TITLE
openssh: fix CVEs

### DIFF
--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2025-61984.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2025-61984.patch
@@ -1,0 +1,112 @@
+From b4de5cb00e5918ce80b8f9590e616e3bbd769aa3 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 4 Sep 2025 00:29:09 +0000
+Subject: [PATCH] Refuse usernames that include control characters
+
+Since OpenSSH 9.6, all usernames have been subject to validity checking.
+This change tightens the validity checks by refusing usernames that
+include control characters; these can cause surprises when supplied
+adversarially.
+
+This change also relaxes the validity checks in one small way: usernames
+supplied via the configuration file as literals are not subject to these
+validity checks. This allows usernames that contain arbitrary characters
+to be used, but only via configuration files. This is done on the basis
+that ssh's configuration is trusted.
+
+Pointed out by David Leadbeater, ok deraadt@
+
+[cjwatson: The original upstream change also improved rules for
+%-expansion of usernames.  However, %-expansion of usernames was only
+introduced in OpenSSH 10.0 and so is not relevant to Debian 12 and
+earlier.]
+
+OpenBSD-Commit-ID: e2f0c871fbe664aba30607321575e7c7fc798362
+
+Origin: backport, https://anongit.mindrot.org/openssh.git/commit/?id=35d5917652106aede47621bb3f64044604164043
+Author: Colin Watson <cjwatson@debian.org>
+Bug-Debian: https://bugs.debian.org/1117529
+Last-Update: 2026-05-11
+
+Patch-Name: CVE-2025-61984.patch
+
+CVE: CVE-2025-61984
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/35d5917652106aede47621bb3f64044604164043]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ ssh.c | 19 ++++++++++++++++---
+ 1 file changed, 16 insertions(+), 3 deletions(-)
+
+diff --git a/ssh.c b/ssh.c
+index 2cf0b64..b6d182d 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -606,6 +606,8 @@ valid_ruser(const char *s)
+ 	if (*s == '-')
+ 		return 0;
+ 	for (i = 0; s[i] != 0; i++) {
++		if (iscntrl((u_char)s[i]))
++			return 0;
+ 		if (strchr("'`\";&<>|(){}", s[i]) != NULL)
+ 			return 0;
+ 		/* Disallow '-' after whitespace */
+@@ -627,6 +629,7 @@ main(int ac, char **av)
+ 	struct ssh *ssh = NULL;
+ 	int i, r, opt, exit_status, use_syslog, direct, timeout_ms;
+ 	int was_addr, config_test = 0, opt_terminated = 0, want_final_pass = 0;
++	int user_on_commandline = 0;
+ 	char *p, *cp, *line, *argv0, buf[PATH_MAX], *logfile;
+ 	char cname[NI_MAXHOST];
+ 	struct stat st;
+@@ -971,8 +974,10 @@ main(int ac, char **av)
+ 			}
+ 			break;
+ 		case 'l':
+-			if (options.user == NULL)
++			if (options.user == NULL) {
+ 				options.user = optarg;
++				user_on_commandline = 1;
++			}
+ 			break;
+ 
+ 		case 'L':
+@@ -1069,6 +1074,7 @@ main(int ac, char **av)
+ 			if (options.user == NULL) {
+ 				options.user = tuser;
+ 				tuser = NULL;
++				user_on_commandline = 1;
+ 			}
+ 			free(tuser);
+ 			if (options.port == -1 && tport != -1)
+@@ -1083,6 +1089,7 @@ main(int ac, char **av)
+ 				if (options.user == NULL) {
+ 					options.user = p;
+ 					p = NULL;
++					user_on_commandline = 1;
+ 				}
+ 				*cp++ = '\0';
+ 				host = xstrdup(cp);
+@@ -1104,8 +1111,6 @@ main(int ac, char **av)
+ 
+ 	if (!valid_hostname(host))
+ 		fatal("hostname contains invalid characters");
+-	if (options.user != NULL && !valid_ruser(options.user))
+-		fatal("remote username contains invalid characters");
+ 	host_arg = xstrdup(host);
+ 
+ 	/* Initialize the command to execute on remote host. */
+@@ -1370,6 +1375,14 @@ main(int ac, char **av)
+ 	ssh_digest_free(md);
+ 	conn_hash_hex = tohex(conn_hash, ssh_digest_bytes(SSH_DIGEST_SHA1));
+ 
++	/*
++	 * Usernames specified on the commandline must be validated.
++	 * Conversely, usernames from getpwnam(3) or specified as literals
++	 * via configuration are not subject to validation.
++	 */
++	if (user_on_commandline && !valid_ruser(options.user))
++		fatal("remote username contains invalid characters");
++
+ 	/*
+ 	 * Expand tokens in arguments. NB. LocalCommand is expanded later,
+ 	 * after port-forwarding is set up, so it may pick up any local

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35385.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35385.patch
@@ -1,0 +1,44 @@
+From 8ac74a2f7b019f988a91a96ce4c228e95f43f12f Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:42:16 +0000
+Subject: [PATCH] upstream: when downloading files as root in legacy (-O) mode
+ and
+
+without the -p (preserve modes) flag set, clear setuid/setgid bits from
+downloaded files as one might expect.
+
+AFAIK this bug dates back to the original Berkeley rcp program.
+
+Reported by Christos Papakonstantinou of Cantina and Spearbit.
+
+OpenBSD-Commit-ID: 49e902fca8dd933a92a9b547ab31f63e86729fa1
+
+Origin: upstream, https://anongit.mindrot.org/openssh.git/commit/?id=487e8ac146f7d6616f65c125d5edb210519b833a
+Bug-Debian: https://bugs.debian.org/1132572
+Last-Update: 2026-05-03
+
+Patch-Name: CVE-2026-35385.patch
+
+CVE: CVE-2026-35385
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/487e8ac146f7d6616f65c125d5edb210519b833a]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ scp.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/scp.c b/scp.c
+index 6901e0c..a442aed 100644
+--- a/scp.c
++++ b/scp.c
+@@ -1255,8 +1255,10 @@ sink(int argc, char **argv, const char *src)
+ 
+ 	setimes = targisdir = 0;
+ 	mask = umask(0);
+-	if (!pflag)
++	if (!pflag) {
++		mask |= 07000;
+ 		(void) umask(mask);
++	}
+ 	if (argc != 1) {
+ 		run_err("ambiguous target");
+ 		exit(1);

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-01.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-01.patch
@@ -1,0 +1,318 @@
+From 04b9959bd10249fe7894af9b4627c2e2365326cb Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Mon, 30 Mar 2026 07:18:24 +0000
+Subject: [PATCH] upstream: apply the same validity rules to usernames and
+ hostnames
+
+set for ProxyJump/-J on the commandline as we do for destination user/host
+names.
+
+Specifically, they are no longer allowed to contain most characters
+that have special meaning for common shells. Special characters are
+still allowed in ProxyJump commands that are specified in the config
+files.
+
+This _reduces_ the chance that shell characters from a hostile -J
+option from ending up in a shell execution context.
+
+Don't pass untrusted stuff to the ssh commandline, it's not intended
+to be a security boundary. We try to make it safe where we can, but
+we can't make guarantees, because we can't know the parsing rules
+and special characters for all the shells in the world, nor can we
+know what the user does with this data in their ssh_config wrt
+percent expansion, LocalCommand, match exec, etc.
+
+While I'm in there, make ProxyJump and ProxyCommand first-match-wins
+between each other.
+
+reported by rabbit; ok dtucker@
+
+OpenBSD-Commit-ID: f05ad8a1eb5f6735f9a935a71a90580226759263
+
+Origin: backport, https://anongit.mindrot.org/openssh.git/commit/?id=0a0ef4515361143cad21afa072319823854c1cf6
+Bug-Debian: https://bugs.debian.org/1132573
+Last-Update: 2026-05-11
+
+Patch-Name: CVE-2026-35386-1.patch
+
+CVE: CVE-2026-35386
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/0a0ef4515361143cad21afa072319823854c1cf6]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ readconf.c | 123 ++++++++++++++++++++++++++++++++++++++---------------
+ readconf.h |   4 +-
+ ssh.c      |  48 +++------------------
+ 3 files changed, 98 insertions(+), 77 deletions(-)
+
+diff --git a/readconf.c b/readconf.c
+index f3cac6b..d0eef0c 100644
+--- a/readconf.c
++++ b/readconf.c
+@@ -1194,9 +1194,6 @@ parse_char_array:
+ 
+ 	case oProxyCommand:
+ 		charptr = &options->proxy_command;
+-		/* Ignore ProxyCommand if ProxyJump already specified */
+-		if (options->jump_host != NULL)
+-			charptr = &options->jump_host; /* Skip below */
+ parse_command:
+ 		if (s == NULL)
+ 			fatal("%.200s line %d: Missing argument.", filename, linenum);
+@@ -1211,7 +1208,7 @@ parse_command:
+ 			    filename, linenum);
+ 		}
+ 		len = strspn(s, WHITESPACE "=");
+-		if (parse_jump(s + len, options, *activep) == -1) {
++		if (parse_jump(s + len, options, cmdline, *activep) == -1) {
+ 			fatal("%.200s line %d: Invalid ProxyJump \"%s\"",
+ 			    filename, linenum, s + len);
+ 		}
+@@ -2453,57 +2450,115 @@ parse_forward(struct Forward *fwd, const char *fwdspec, int dynamicfwd, int remo
+ }
+ 
+ int
+-parse_jump(const char *s, Options *o, int active)
++ssh_valid_hostname(const char *s)
+ {
+-	char *orig, *sdup, *cp;
+-	char *host = NULL, *user = NULL;
+-	int ret = -1, port = -1, first;
++	size_t i;
+ 
+-	active &= o->proxy_command == NULL && o->jump_host == NULL;
++	if (*s == '-')
++		return 0;
++	for (i = 0; s[i] != 0; i++) {
++		if (strchr("'`\"$\\;&<>|(){},", s[i]) != NULL ||
++		    isspace((u_char)s[i]) || iscntrl((u_char)s[i]))
++			return 0;
++	}
++	return 1;
++}
++
++int
++ssh_valid_ruser(const char *s)
++{
++	size_t i;
++
++	if (*s == '-')
++		return 0;
++	for (i = 0; s[i] != 0; i++) {
++		if (iscntrl((u_char)s[i]))
++			return 0;
++		if (strchr("'`\";&<>|(){}", s[i]) != NULL)
++			return 0;
++		/* Disallow '-' after whitespace */
++		if (isspace((u_char)s[i]) && s[i + 1] == '-')
++			return 0;
++		/* Disallow \ in last position */
++		if (s[i] == '\\' && s[i + 1] == '\0')
++			return 0;
++	}
++	return 1;
++}
++
++int
++parse_jump(const char *s, Options *o, int strict, int active)
++{
++	char *orig = NULL, *sdup = NULL, *cp;
++	char *tmp_user = NULL, *tmp_host = NULL, *host = NULL, *user = NULL;
++	int r, ret = -1, tmp_port = -1, port = -1, first = 1;
++
++	if (strcasecmp(s, "none") == 0) {
++		if (active && o->jump_host == NULL) {
++			o->jump_host = xstrdup("none");
++			o->jump_port = 0;
++		}
++		return 0;
++	}
++
++	orig = xstrdup(s);
+ 
+-	orig = sdup = xstrdup(s);
+-	first = active;
++	active &= o->proxy_command == NULL && o->jump_host == NULL;
++	sdup = xstrdup(orig);
+ 	do {
+-		if (strcasecmp(s, "none") == 0)
+-			break;
++		/* Work backwards through string */
+ 		if ((cp = strrchr(sdup, ',')) == NULL)
+ 			cp = sdup; /* last */
+ 		else
+ 			*cp++ = '\0';
+ 
+-		if (first) {
+-			/* First argument and configuration is active */
+-			if (parse_ssh_uri(cp, &user, &host, &port) == -1 ||
+-			    parse_user_host_port(cp, &user, &host, &port) != 0)
++		r = parse_ssh_uri(cp, &tmp_user, &tmp_host, &tmp_port);
++		if (r == -1 || (r == 1 && parse_user_host_port(cp,
++		    &tmp_user, &tmp_host, &tmp_port) != 0))
++			goto out; /* error already logged */
++		if (strict) {
++			if (!ssh_valid_hostname(tmp_host)) {
++				error("%s: invalid hostname \"%s\"", __func__,
++				    tmp_host);
+ 				goto out;
+-		} else {
+-			/* Subsequent argument or inactive configuration */
+-			if (parse_ssh_uri(cp, NULL, NULL, NULL) == -1 ||
+-			    parse_user_host_port(cp, NULL, NULL, NULL) != 0)
++			}
++			if (tmp_user != NULL && !ssh_valid_ruser(tmp_user)) {
++				error("%s: invalid username \"%s\"", __func__,
++				    tmp_user);
+ 				goto out;
++			}
++		}
++		if (first) {
++			user = tmp_user;
++			host = tmp_host;
++			port = tmp_port;
++			tmp_user = tmp_host = NULL; /* transferred */
+ 		}
+ 		first = 0; /* only check syntax for subsequent hosts */
++		free(tmp_user);
++		free(tmp_host);
++		tmp_user = tmp_host = NULL;
++		tmp_port = -1;
+ 	} while (cp != sdup);
++
+ 	/* success */
+ 	if (active) {
+-		if (strcasecmp(s, "none") == 0) {
+-			o->jump_host = xstrdup("none");
+-			o->jump_port = 0;
+-		} else {
+-			o->jump_user = user;
+-			o->jump_host = host;
+-			o->jump_port = port;
+-			o->proxy_command = xstrdup("none");
+-			user = host = NULL;
+-			if ((cp = strrchr(s, ',')) != NULL && cp != s) {
+-				o->jump_extra = xstrdup(s);
+-				o->jump_extra[cp - s] = '\0';
+-			}
++		o->jump_user = user;
++		o->jump_host = host;
++		o->jump_port = port;
++		o->proxy_command = xstrdup("none");
++		user = host = NULL; /* transferred */
++		if (orig != NULL && (cp = strrchr(orig, ',')) != NULL) {
++			o->jump_extra = xstrdup(orig);
++			o->jump_extra[cp - orig] = '\0';
+ 		}
+ 	}
+ 	ret = 0;
+  out:
+ 	free(orig);
++	free(sdup);
++	free(tmp_user);
++	free(tmp_host);
+ 	free(user);
+ 	free(host);
+ 	return ret;
+diff --git a/readconf.h b/readconf.h
+index feedb3d..04d3314 100644
+--- a/readconf.h
++++ b/readconf.h
+@@ -208,7 +208,9 @@ int	 process_config_line(Options *, struct passwd *, const char *,
+ int	 read_config_file(const char *, struct passwd *, const char *,
+     const char *, Options *, int, int *);
+ int	 parse_forward(struct Forward *, const char *, int, int);
+-int	 parse_jump(const char *, Options *, int);
++int	 ssh_valid_hostname(const char *);
++int	 ssh_valid_ruser(const char *);
++int	 parse_jump(const char *, Options *, int, int);
+ int	 parse_ssh_uri(const char *, char **, char **, int *);
+ int	 default_ssh_port(void);
+ int	 option_clear_or_none(const char *);
+diff --git a/ssh.c b/ssh.c
+index b6d182d..4741a3b 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -583,43 +583,6 @@ set_addrinfo_port(struct addrinfo *addrs, int port)
+ 	}
+ }
+ 
+-static int
+-valid_hostname(const char *s)
+-{
+-	size_t i;
+-
+-	if (*s == '-')
+-		return 0;
+-	for (i = 0; s[i] != 0; i++) {
+-		if (strchr("'`\"$\\;&<>|(){}", s[i]) != NULL ||
+-		    isspace((u_char)s[i]) || iscntrl((u_char)s[i]))
+-			return 0;
+-	}
+-	return 1;
+-}
+-
+-static int
+-valid_ruser(const char *s)
+-{
+-	size_t i;
+-
+-	if (*s == '-')
+-		return 0;
+-	for (i = 0; s[i] != 0; i++) {
+-		if (iscntrl((u_char)s[i]))
+-			return 0;
+-		if (strchr("'`\";&<>|(){}", s[i]) != NULL)
+-			return 0;
+-		/* Disallow '-' after whitespace */
+-		if (isspace((u_char)s[i]) && s[i + 1] == '-')
+-			return 0;
+-		/* Disallow \ in last position */
+-		if (s[i] == '\\' && s[i + 1] == '\0')
+-			return 0;
+-	}
+-	return 1;
+-}
+-
+ /*
+  * Main program for the ssh client.
+  */
+@@ -858,9 +821,9 @@ main(int ac, char **av)
+ 			}
+ 			if (options.proxy_command != NULL)
+ 				fatal("Cannot specify -J with ProxyCommand");
+-			if (parse_jump(optarg, &options, 1) == -1)
++			if (parse_jump(optarg, &options, 1, 1) == -1)
++
+ 				fatal("Invalid -J argument");
+-			options.proxy_command = xstrdup("none");
+ 			break;
+ 		case 't':
+ 			if (options.request_tty == REQUEST_TTY_YES)
+@@ -1109,7 +1072,7 @@ main(int ac, char **av)
+ 	if (!host)
+ 		usage();
+ 
+-	if (!valid_hostname(host))
++	if (!ssh_valid_hostname(host))
+ 		fatal("hostname contains invalid characters");
+ 	host_arg = xstrdup(host);
+ 
+@@ -1261,7 +1224,8 @@ main(int ac, char **av)
+ 			sshbin = "ssh";
+ 
+ 		/* Consistency check */
+-		if (options.proxy_command != NULL)
++		if (options.proxy_command != NULL &&
++		    strcasecmp(options.proxy_command, "none") != 0)
+ 			fatal("inconsistent options: ProxyCommand+ProxyJump");
+ 		/* Never use FD passing for ProxyJump */
+ 		options.proxy_use_fdpass = 0;
+@@ -1380,7 +1344,7 @@ main(int ac, char **av)
+ 	 * Conversely, usernames from getpwnam(3) or specified as literals
+ 	 * via configuration are not subject to validation.
+ 	 */
+-	if (user_on_commandline && !valid_ruser(options.user))
++	if (user_on_commandline && !ssh_valid_ruser(options.user))
+ 		fatal("remote username contains invalid characters");
+ 
+ 	/*

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-02.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-02.patch
@@ -1,0 +1,59 @@
+From acdadd74a326036fb9c09f2570071fd6dc8e6095 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:50:55 +0000
+Subject: [PATCH] upstream: move username validity check for usernames
+ specified on
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+the commandline to earlier in main(), specifically before some contexts where
+a username with shell characters might be expanded by a %u directive in
+ssh_config.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We continue to recommend against using untrusted input on
+the SSH commandline. Mitigations like this are not 100%
+guarantees of safety because we can't control every
+combination of user shell and configuration where they are
+used.
+
+Reported by Florian Kohnhäuser
+
+OpenBSD-Commit-ID: 25ef72223f5ccf1c38d307ae77c23c03f59acc55
+
+Origin: backport, https://anongit.mindrot.org/openssh.git/commit/?id=76685c9b09a66435cd2ad8373246adf1c53976d3
+Bug-Debian: https://bugs.debian.org/1132573
+Last-Update: 2026-05-11
+
+Patch-Name: CVE-2026-35386-2.patch
+
+CVE: CVE-2026-35386
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/76685c9b09a66435cd2ad8373246adf1c53976d3]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ ssh.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/ssh.c b/ssh.c
+index 4741a3b..431c664 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -1072,8 +1072,15 @@ main(int ac, char **av)
+ 	if (!host)
+ 		usage();
+ 
++	/*
++	 * Validate commandline-specified values that end up in %tokens
++	 * before they are used in config parsing.
++	 */
++	if (options.user != NULL && !ssh_valid_ruser(options.user))
++		fatal("remote username contains invalid characters");
+ 	if (!ssh_valid_hostname(host))
+ 		fatal("hostname contains invalid characters");
++
+ 	host_arg = xstrdup(host);
+ 
+ 	/* Initialize the command to execute on remote host. */

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35387.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35387.patch
@@ -1,0 +1,140 @@
+From eea419e85e0628a83b6ded97d189f064f5a9130e Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:48:13 +0000
+Subject: [PATCH] upstream: correctly match ECDSA signature algorithms against
+
+algorithm allowlists: HostKeyAlgorithms, PubkeyAcceptedAlgorithms and
+HostbasedAcceptedAlgorithms.
+
+Previously, if any ECDSA type (say "ecdsa-sha2-nistp521") was
+present in one of these lists, then all ECDSA algorithms would
+be permitted.
+
+Reported by Christos Papakonstantinou of Cantina and Spearbit.
+
+OpenBSD-Commit-ID: c790e2687c35989ae34a00e709be935c55b16a86
+
+[cjwatson: Committed upstream together with apparently-unrelated changes
+for CVE-2026-35414.  I've split them into separate patches for clarity.]
+
+Origin: backport, https://anongit.mindrot.org/openssh.git/commit/?id=fd1c7e131f331942d20f42f31e79912d570081fa
+Bug-Debian: https://bugs.debian.org/1132574
+Last-Update: 2026-05-11
+
+Change-Id: I9339cf797d1590dccd82b67184375de42ebbc14c
+Patch-Name: CVE-2026-35387.patch
+
+CVE: CVE-2026-35387
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/fd1c7e131f331942d20f42f31e79912d570081fa]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ auth2-hostbased.c |  8 +++++---
+ auth2-pubkey.c    |  8 +++++---
+ sshconnect2.c     | 26 +++++++++++++++++---------
+ 3 files changed, 27 insertions(+), 15 deletions(-)
+
+diff --git a/auth2-hostbased.c b/auth2-hostbased.c
+index 5e9b7c6..fdb69c5 100644
+--- a/auth2-hostbased.c
++++ b/auth2-hostbased.c
+@@ -97,9 +97,11 @@ userauth_hostbased(struct ssh *ssh)
+ 		error("%s: cannot decode key: %s", __func__, pkalg);
+ 		goto done;
+ 	}
+-	if (key->type != pktype) {
+-		error("%s: type mismatch for decoded key "
+-		    "(received %d, expected %d)", __func__, key->type, pktype);
++	if (key->type != pktype || (sshkey_type_plain(pktype) == KEY_ECDSA &&
++	    sshkey_ecdsa_nid_from_name(pkalg) != key->ecdsa_nid)) {
++		error("%s: key type mismatch for decoded key "
++		    "(received %s, expected %s)", __func__,
++		    sshkey_ssh_name(key), pkalg);
+ 		goto done;
+ 	}
+ 	if (sshkey_type_plain(key->type) == KEY_RSA &&
+diff --git a/auth2-pubkey.c b/auth2-pubkey.c
+index 815ea0f..b42f4e1 100644
+--- a/auth2-pubkey.c
++++ b/auth2-pubkey.c
+@@ -136,9 +136,11 @@ userauth_pubkey(struct ssh *ssh)
+ 		error("%s: cannot decode key: %s", __func__, pkalg);
+ 		goto done;
+ 	}
+-	if (key->type != pktype) {
+-		error("%s: type mismatch for decoded key "
+-		    "(received %d, expected %d)", __func__, key->type, pktype);
++	if (key->type != pktype || (sshkey_type_plain(pktype) == KEY_ECDSA &&
++	    sshkey_ecdsa_nid_from_name(pkalg) != key->ecdsa_nid)) {
++		error("%s: key type mismatch for decoded key "
++		    "(received %s, expected %s)", __func__,
++		    sshkey_ssh_name(key), pkalg);
+ 		goto done;
+ 	}
+ 	if (sshkey_type_plain(key->type) == KEY_RSA &&
+diff --git a/sshconnect2.c b/sshconnect2.c
+index 7dbbeda..0293c85 100644
+--- a/sshconnect2.c
++++ b/sshconnect2.c
+@@ -93,10 +93,15 @@ u_int session_id2_len = 0;
+ 
+ char *xxx_host;
+ struct sockaddr *xxx_hostaddr;
++static int key_type_allowed(struct sshkey *, const char *);
+ 
+ static int
+ verify_host_key_callback(struct sshkey *hostkey, struct ssh *ssh)
+ {
++	if (!key_type_allowed(hostkey, options.hostkeyalgorithms)) {
++		fatal("Server host key %s not in HostKeyAlgorithms",
++		    sshkey_ssh_name(hostkey));
++	}
+ 	if (verify_host_key(xxx_host, xxx_hostaddr, hostkey) != 0)
+ 		fatal("Host key verification failed.");
+ 	return 0;
+@@ -1550,34 +1555,37 @@ load_identity_file(Identity *id)
+ }
+ 
+ static int
+-key_type_allowed_by_config(struct sshkey *key)
++key_type_allowed(struct sshkey *key, const char *allowlist)
+ {
+-	if (match_pattern_list(sshkey_ssh_name(key),
+-	    options.pubkey_key_types, 0) == 1)
++	if (match_pattern_list(sshkey_ssh_name(key), allowlist, 0) == 1)
+ 		return 1;
+ 
+ 	/* RSA keys/certs might be allowed by alternate signature types */
+ 	switch (key->type) {
+ 	case KEY_RSA:
+-		if (match_pattern_list("rsa-sha2-512",
+-		    options.pubkey_key_types, 0) == 1)
++		if (match_pattern_list("rsa-sha2-512", allowlist, 0) == 1)
+ 			return 1;
+-		if (match_pattern_list("rsa-sha2-256",
+-		    options.pubkey_key_types, 0) == 1)
++		if (match_pattern_list("rsa-sha2-256", allowlist, 0) == 1)
+ 			return 1;
+ 		break;
+ 	case KEY_RSA_CERT:
+ 		if (match_pattern_list("rsa-sha2-512-cert-v01@openssh.com",
+-		    options.pubkey_key_types, 0) == 1)
++		    allowlist, 0) == 1)
+ 			return 1;
+ 		if (match_pattern_list("rsa-sha2-256-cert-v01@openssh.com",
+-		    options.pubkey_key_types, 0) == 1)
++		    allowlist, 0) == 1)
+ 			return 1;
+ 		break;
+ 	}
+ 	return 0;
+ }
+ 
++static int
++key_type_allowed_by_config(struct sshkey *key)
++{
++	return key_type_allowed(key, options.pubkey_key_types);
++}
++
+ 
+ /*
+  * try keys in the following order:

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI_append = " \
     file://CVE-2025-26465.patch \
     file://CVE-2025-32728.patch \
+    file://CVE-2025-61984.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -6,6 +6,8 @@ SRC_URI_append = " \
     file://CVE-2025-61984.patch \
     file://CVE-2026-35385.patch \
     file://CVE-2026-35387.patch \
+    file://CVE-2026-35386-01.patch \
+    file://CVE-2026-35386-02.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -5,6 +5,7 @@ SRC_URI_append = " \
     file://CVE-2025-32728.patch \
     file://CVE-2025-61984.patch \
     file://CVE-2026-35385.patch \
+    file://CVE-2026-35387.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -4,6 +4,7 @@ SRC_URI_append = " \
     file://CVE-2025-26465.patch \
     file://CVE-2025-32728.patch \
     file://CVE-2025-61984.patch \
+    file://CVE-2026-35385.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and


### PR DESCRIPTION
Fix the following CVEs -
CVE-2025-61984 CVE-2026-35385 CVE-2026-35387 CVE-2026-35386
source is the patch files from: debian/openssh 1:8.4p1-5+deb11u7