### PR TITLE
openssh: kirkstone: fix CVEs

### DIFF
--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2025-61984-tests.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2025-61984-tests.patch
@@ -1,0 +1,86 @@
+From 2d4014d58741293dd534d51e77a8ab8014baf8b0 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 4 Sep 2025 03:04:44 +0000
+Subject: [PATCH] Add more username validity checks
+
+[cjwatson: Reduced from a more extensive upstream change, since OpenSSH
+< 10.0 doesn't support %-expansion of usernames.]
+
+OpenBSD-Regress-ID: ad4c12c70bdf1f959abfebd1637ecff1b49a484c
+
+Origin: backport, https://anongit.mindrot.org/openssh.git/commit/?id=f64701ca25795548a61614d0b13391d6dfa7f38c
+Author: Colin Watson <cjwatson@debian.org>
+Bug-Debian: https://bugs.debian.org/1117530
+Last-Update: 2026-01-09
+
+Patch-Name: CVE-2025-61984-tests.patch
+
+CVE: CVE-2025-61984
+Upstream-Status: Backport [https://salsa.debian.org/ssh-team/openssh/-/commit/c951523d46d4a953799858a10fd8204247d137ea]
+Signed-off-by: Andrej Koehler <andrej.koehler@gmx.net>
+---
+ regress/percent.sh | 37 +++++++++++++++++++++++++++++++++++--
+ 1 file changed, 35 insertions(+), 2 deletions(-)
+
+diff --git a/regress/percent.sh b/regress/percent.sh
+index bb81779..fd48156 100644
+--- a/regress/percent.sh
++++ b/regress/percent.sh
+@@ -33,6 +33,20 @@ trial()
+ 		    somehost true
+ 		got=`cat $OBJ/actual`
+ 		;;
++	user)
++		got=`${SSH} -F $OBJ/ssh_proxy -o $opt="$arg" -G \
++		    remuser@somehost | awk '$1=="'$opt'"{print $2}'`
++		;;
++	user-l)
++		# Also test ssh -l
++		got=`${SSH} -F $OBJ/ssh_proxy -l "$arg" -G \
++		    somehost | awk '$1=="'user'"{print $2}'`
++		;;
++	user-at)
++		# Also test user@host
++		got=`${SSH} -F $OBJ/ssh_proxy -G "$arg@somehost" | \
++		    awk '$1=="'user'"{print $2}'`
++		;;
+ 	userknownhostsfile)
+ 		# Move the userknownhosts file to what the expansion says,
+ 		# make sure ssh works then put it back.
+@@ -103,11 +117,11 @@ done
+ 
+ # Subset of above since we don't expand shell-style variables on anything that
+ # runs a command because the shell will expand those.
++FOO=bar
++export FOO
+ for i in controlpath identityagent forwardagent localforward remoteforward \
+     userknownhostsfile; do
+ 	verbose $tid $i dollar
+-	FOO=bar
+-	export FOO
+ 	trial $i '${FOO}' $FOO
+ done
+ 
+@@ -118,3 +132,22 @@ for i in controlpath identityagent forwardagent; do
+ 	trial $i '~' $HOME/
+ 	trial $i '~/.ssh' $HOME/.ssh
+ done
++
++# These should be not be expanded but rejected for containing shell characters.
++verbose $tid user-l noenv
++${SSH} -F $OBJ/ssh_proxy -l '${FOO}' -G somehost && fail "user-l expanded env"
++verbose $tid user-at noenv
++${SSH} -F $OBJ/ssh_proxy -G '${FOO}@somehost' && fail "user-at expanded env"
++
++FOO=`printf 'x\ay'`
++export FOO
++
++# These should be rejected as containing control characters.
++verbose $tid user-l badchar
++${SSH} -F $OBJ/ssh_proxy -l "${FOO}" -G somehost && fail "user-l expanded env"
++verbose $tid user-at badchar
++${SSH} -F $OBJ/ssh_proxy -G "${FOO}@somehost" && fail "user-at expanded env"
++
++# Literal control characters in config is acceptable
++verbose $tid user control-literal
++trial user "$FOO" "$FOO"

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2025-61984.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2025-61984.patch
@@ -1,0 +1,115 @@
+From 31027ba3815f41cb77db1a49a55cdc0eba6ba1a3 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 4 Sep 2025 00:29:09 +0000
+Subject: [PATCH] Refuse usernames that include control characters
+
+Since OpenSSH 9.6, all usernames have been subject to validity checking.
+This change tightens the validity checks by refusing usernames that
+include control characters; these can cause surprises when supplied
+adversarially.
+
+This change also relaxes the validity checks in one small way: usernames
+supplied via the configuration file as literals are not subject to these
+validity checks. This allows usernames that contain arbitrary characters
+to be used, but only via configuration files. This is done on the basis
+that ssh's configuration is trusted.
+
+Pointed out by David Leadbeater, ok deraadt@
+
+[cjwatson: The original upstream change also improved rules for
+%-expansion of usernames.  However, %-expansion of usernames was only
+introduced in OpenSSH 10.0 and so is not relevant to Debian 12 and
+earlier.]
+
+OpenBSD-Commit-ID: e2f0c871fbe664aba30607321575e7c7fc798362
+
+Origin: backport, https://anongit.mindrot.org/openssh.git/commit/?id=35d5917652106aede47621bb3f64044604164043
+Author: Colin Watson <cjwatson@debian.org>
+Bug-Debian: https://bugs.debian.org/1117529
+Last-Update: 2026-05-11
+
+Patch-Name: CVE-2025-61984.patch
+
+[CVE-2025-61984.patch file in kirkstone upstream is incomplete. It contains the
+variable declarations and initialization, but the actual code that uses it is missing.]
+
+CVE: CVE-2025-61984
+Upstream-Status: Backport [https://salsa.debian.org/ssh-team/openssh/-/commit/0a03d5cbc258c2ef5e7a117d6ba844daa599193a]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ ssh.c | 19 ++++++++++++++++---
+ 1 file changed, 16 insertions(+), 3 deletions(-)
+
+diff --git a/ssh.c b/ssh.c
+index 82ed15f8f..72a5b16f7 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -634,6 +634,8 @@ valid_ruser(const char *s)
+ 	if (*s == '-')
+ 		return 0;
+ 	for (i = 0; s[i] != 0; i++) {
++		if (iscntrl((u_char)s[i]))
++			return 0;
+ 		if (strchr("'`\";&<>|(){}", s[i]) != NULL)
+ 			return 0;
+ 		/* Disallow '-' after whitespace */
+@@ -655,6 +657,7 @@ main(int ac, char **av)
+ 	struct ssh *ssh = NULL;
+ 	int i, r, opt, exit_status, use_syslog, direct, timeout_ms;
+ 	int was_addr, config_test = 0, opt_terminated = 0, want_final_pass = 0;
++	int user_on_commandline = 0;
+ 	char *p, *cp, *line, *argv0, *logfile, *host_arg;
+ 	char cname[NI_MAXHOST], thishost[NI_MAXHOST];
+ 	struct stat st;
+@@ -995,8 +998,10 @@ main(int ac, char **av)
+ 			}
+ 			break;
+ 		case 'l':
+-			if (options.user == NULL)
++			if (options.user == NULL) {
+ 				options.user = optarg;
++				user_on_commandline = 1;
++			}
+ 			break;
+ 
+ 		case 'L':
+@@ -1099,6 +1104,7 @@ main(int ac, char **av)
+ 			if (options.user == NULL) {
+ 				options.user = tuser;
+ 				tuser = NULL;
++				user_on_commandline = 1;
+ 			}
+ 			free(tuser);
+ 			if (options.port == -1 && tport != -1)
+@@ -1113,6 +1119,7 @@ main(int ac, char **av)
+ 				if (options.user == NULL) {
+ 					options.user = p;
+ 					p = NULL;
++					user_on_commandline = 1;
+ 				}
+ 				*cp++ = '\0';
+ 				host = xstrdup(cp);
+@@ -1134,8 +1141,6 @@ main(int ac, char **av)
+ 
+ 	if (!valid_hostname(host))
+ 		fatal("hostname contains invalid characters");
+-	if (options.user != NULL && !valid_ruser(options.user))
+-		fatal("remote username contains invalid characters");
+ 	host_arg = xstrdup(host);
+ 
+ 	/* Initialize the command to execute on remote host. */
+@@ -1413,6 +1418,14 @@ main(int ac, char **av)
+ 	cinfo->homedir = xstrdup(pw->pw_dir);
+ 	cinfo->locuser = xstrdup(pw->pw_name);
+ 
++	/*
++	 * Usernames specified on the commandline must be validated.
++	 * Conversely, usernames from getpwnam(3) or specified as literals
++	 * via configuration are not subject to validation.
++	 */
++	if (user_on_commandline && !valid_ruser(options.user))
++		fatal("remote username contains invalid characters");
++
+ 	/*
+ 	 * Expand tokens in arguments. NB. LocalCommand is expanded later,
+ 	 * after port-forwarding is set up, so it may pick up any local

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35385.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35385.patch
@@ -1,0 +1,38 @@
+From 494c1b7c8c29b9822506d4910d760d6e03947be7 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:42:16 +0000
+Subject: [PATCH] upstream: when downloading files as root in legacy (-O) mode
+ and
+
+without the -p (preserve modes) flag set, clear setuid/setgid bits from
+downloaded files as one might expect.
+
+AFAIK this bug dates back to the original Berkeley rcp program.
+
+Reported by Christos Papakonstantinou of Cantina and Spearbit.
+
+OpenBSD-Commit-ID: 49e902fca8dd933a92a9b547ab31f63e86729fa1
+
+CVE: CVE-2026-35385
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/487e8ac146f7d6616f65c125d5edb210519b833a]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ scp.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/scp.c b/scp.c
+index 519bffa1b..2e37da4a3 100644
+--- a/scp.c
++++ b/scp.c
+@@ -1606,8 +1606,10 @@ sink(int argc, char **argv, const char *src)
+ 
+ 	setimes = targisdir = 0;
+ 	mask = umask(0);
+-	if (!pflag)
++	if (!pflag) {
++		mask |= 07000;
+ 		(void) umask(mask);
++	}
+ 	if (argc != 1) {
+ 		run_err("ambiguous target");
+ 		exit(1);

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-01.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-01.patch
@@ -1,0 +1,316 @@
+From 03f48bf94b98fd9454cd8d8e1b4febb57c082a4a Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Mon, 30 Mar 2026 07:18:24 +0000
+Subject: [PATCH] upstream: apply the same validity rules to usernames and
+ hostnames
+
+set for ProxyJump/-J on the commandline as we do for destination user/host
+names.
+
+Specifically, they are no longer allowed to contain most characters
+that have special meaning for common shells. Special characters are
+still allowed in ProxyJump commands that are specified in the config
+files.
+
+This _reduces_ the chance that shell characters from a hostile -J
+option from ending up in a shell execution context.
+
+Don't pass untrusted stuff to the ssh commandline, it's not intended
+to be a security boundary. We try to make it safe where we can, but
+we can't make guarantees, because we can't know the parsing rules
+and special characters for all the shells in the world, nor can we
+know what the user does with this data in their ssh_config wrt
+percent expansion, LocalCommand, match exec, etc.
+
+While I'm in there, make ProxyJump and ProxyCommand first-match-wins
+between each other.
+
+reported by rabbit; ok dtucker@
+
+OpenBSD-Commit-ID: f05ad8a1eb5f6735f9a935a71a90580226759263
+
+CVE: CVE-2026-35386
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/0a0ef4515361143cad21afa072319823854c1cf6]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ readconf.c | 122 +++++++++++++++++++++++++++++++++++++----------------
+ readconf.h |   4 +-
+ ssh.c      |  48 +++------------------
+ 3 files changed, 94 insertions(+), 80 deletions(-)
+
+diff --git a/readconf.c b/readconf.c
+index f26fabaa6..438b84ce6 100644
+--- a/readconf.c
++++ b/readconf.c
+@@ -1328,9 +1328,6 @@ parse_char_array:
+ 
+ 	case oProxyCommand:
+ 		charptr = &options->proxy_command;
+-		/* Ignore ProxyCommand if ProxyJump already specified */
+-		if (options->jump_host != NULL)
+-			charptr = &options->jump_host; /* Skip below */
+ parse_command:
+ 		if (str == NULL) {
+ 			error("%.200s line %d: Missing argument.",
+@@ -1351,7 +1348,7 @@ parse_command:
+ 		}
+ 		len = strspn(str, WHITESPACE "=");
+ 		/* XXX use argv? */
+-		if (parse_jump(str + len, options, *activep) == -1) {
++		if (parse_jump(str + len, options, cmdline, *activep) == -1) {
+ 			error("%.200s line %d: Invalid ProxyJump \"%s\"",
+ 			    filename, linenum, str + len);
+ 			goto out;
+@@ -3017,65 +3014,116 @@ parse_forward(struct Forward *fwd, const char *fwdspec, int dynamicfwd, int remo
+ }
+ 
+ int
+-parse_jump(const char *s, Options *o, int active)
++ssh_valid_hostname(const char *s)
+ {
+-	char *orig, *sdup, *cp;
+-	char *host = NULL, *user = NULL;
+-	int r, ret = -1, port = -1, first;
++	size_t i;
+ 
+-	active &= o->proxy_command == NULL && o->jump_host == NULL;
++	if (*s == '-')
++		return 0;
++	for (i = 0; s[i] != 0; i++) {
++		if (strchr("'`\"$\\;&<>|(){},", s[i]) != NULL ||
++		    isspace((u_char)s[i]) || iscntrl((u_char)s[i]))
++			return 0;
++	}
++	return 1;
++}
+ 
+-	orig = sdup = xstrdup(s);
++int
++ssh_valid_ruser(const char *s)
++{
++	size_t i;
++
++	if (*s == '-')
++		return 0;
++	for (i = 0; s[i] != 0; i++) {
++		if (iscntrl((u_char)s[i]))
++			return 0;
++		if (strchr("'`\";&<>|(){}", s[i]) != NULL)
++			return 0;
++		/* Disallow '-' after whitespace */
++		if (isspace((u_char)s[i]) && s[i + 1] == '-')
++			return 0;
++		/* Disallow \ in last position */
++		if (s[i] == '\\' && s[i + 1] == '\0')
++			return 0;
++	}
++	return 1;
++}
++
++int
++parse_jump(const char *s, Options *o, int strict, int active)
++{
++	char *orig = NULL, *sdup = NULL, *cp;
++	char *tmp_user = NULL, *tmp_host = NULL, *host = NULL, *user = NULL;
++	int r, ret = -1, tmp_port = -1, port = -1, first = 1;
++
++	if (strcasecmp(s, "none") == 0) {
++		if (active && o->jump_host == NULL) {
++			o->jump_host = xstrdup("none");
++			o->jump_port = 0;
++		}
++		return 0;
++	}
+ 
+-	/* Remove comment and trailing whitespace */
++	orig = xstrdup(s);
+ 	if ((cp = strchr(orig, '#')) != NULL)
+ 		*cp = '\0';
+ 	rtrim(orig);
+ 
+-	first = active;
++	active &= o->proxy_command == NULL && o->jump_host == NULL;
++	sdup = xstrdup(orig);
+ 	do {
+-		if (strcasecmp(s, "none") == 0)
+-			break;
++		/* Work backwards through string */
+ 		if ((cp = strrchr(sdup, ',')) == NULL)
+ 			cp = sdup; /* last */
+ 		else
+ 			*cp++ = '\0';
+ 
+-		if (first) {
+-			/* First argument and configuration is active */
+-			r = parse_ssh_uri(cp, &user, &host, &port);
+-			if (r == -1 || (r == 1 &&
+-			    parse_user_host_port(cp, &user, &host, &port) != 0))
++		r = parse_ssh_uri(cp, &tmp_user, &tmp_host, &tmp_port);
++		if (r == -1 || (r == 1 && parse_user_host_port(cp,
++		    &tmp_user, &tmp_host, &tmp_port) != 0))
++			goto out; /* error already logged */
++		if (strict) {
++			if (!ssh_valid_hostname(tmp_host)) {
++				error_f("invalid hostname \"%s\"", tmp_host);
+ 				goto out;
+-		} else {
+-			/* Subsequent argument or inactive configuration */
+-			r = parse_ssh_uri(cp, NULL, NULL, NULL);
+-			if (r == -1 || (r == 1 &&
+-			    parse_user_host_port(cp, NULL, NULL, NULL) != 0))
++			}
++			if (tmp_user != NULL && !ssh_valid_ruser(tmp_user)) {
++				error_f("invalid username \"%s\"", tmp_user);
+ 				goto out;
++			}
++		}
++		if (first) {
++			user = tmp_user;
++			host = tmp_host;
++			port = tmp_port;
++			tmp_user = tmp_host = NULL; /* transferred */
+ 		}
+ 		first = 0; /* only check syntax for subsequent hosts */
++		free(tmp_user);
++		free(tmp_host);
++		tmp_user = tmp_host = NULL;
++		tmp_port = -1;
+ 	} while (cp != sdup);
++
+ 	/* success */
+ 	if (active) {
+-		if (strcasecmp(s, "none") == 0) {
+-			o->jump_host = xstrdup("none");
+-			o->jump_port = 0;
+-		} else {
+-			o->jump_user = user;
+-			o->jump_host = host;
+-			o->jump_port = port;
+-			o->proxy_command = xstrdup("none");
+-			user = host = NULL;
+-			if ((cp = strrchr(s, ',')) != NULL && cp != s) {
+-				o->jump_extra = xstrdup(s);
+-				o->jump_extra[cp - s] = '\0';
+-			}
++		o->jump_user = user;
++		o->jump_host = host;
++		o->jump_port = port;
++		o->proxy_command = xstrdup("none");
++		user = host = NULL; /* transferred */
++		if (orig != NULL && (cp = strrchr(orig, ',')) != NULL) {
++			o->jump_extra = xstrdup(orig);
++			o->jump_extra[cp - orig] = '\0';
+ 		}
+ 	}
+ 	ret = 0;
+  out:
+ 	free(orig);
++	free(sdup);
++	free(tmp_user);
++	free(tmp_host);
+ 	free(user);
+ 	free(host);
+ 	return ret;
+diff --git a/readconf.h b/readconf.h
+index ded13c943..568db471c 100644
+--- a/readconf.h
++++ b/readconf.h
+@@ -229,7 +229,9 @@ int	 process_config_line(Options *, struct passwd *, const char *,
+ int	 read_config_file(const char *, struct passwd *, const char *,
+     const char *, Options *, int, int *);
+ int	 parse_forward(struct Forward *, const char *, int, int);
+-int	 parse_jump(const char *, Options *, int);
++int	 ssh_valid_hostname(const char *);
++int	 ssh_valid_ruser(const char *);
++int	 parse_jump(const char *, Options *, int, int);
+ int	 parse_ssh_uri(const char *, char **, char **, int *);
+ int	 default_ssh_port(void);
+ int	 option_clear_or_none(const char *);
+diff --git a/ssh.c b/ssh.c
+index 72a5b16f7..7d6fa9259 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -611,43 +611,6 @@ ssh_conn_info_free(struct ssh_conn_info *cinfo)
+ 	free(cinfo);
+ }
+ 
+-static int
+-valid_hostname(const char *s)
+-{
+-	size_t i;
+-
+-	if (*s == '-')
+-		return 0;
+-	for (i = 0; s[i] != 0; i++) {
+-		if (strchr("'`\"$\\;&<>|(){}", s[i]) != NULL ||
+-		    isspace((u_char)s[i]) || iscntrl((u_char)s[i]))
+-			return 0;
+-	}
+-	return 1;
+-}
+-
+-static int
+-valid_ruser(const char *s)
+-{
+-	size_t i;
+-
+-	if (*s == '-')
+-		return 0;
+-	for (i = 0; s[i] != 0; i++) {
+-		if (iscntrl((u_char)s[i]))
+-			return 0;
+-		if (strchr("'`\";&<>|(){}", s[i]) != NULL)
+-			return 0;
+-		/* Disallow '-' after whitespace */
+-		if (isspace((u_char)s[i]) && s[i + 1] == '-')
+-			return 0;
+-		/* Disallow \ in last position */
+-		if (s[i] == '\\' && s[i + 1] == '\0')
+-			return 0;
+-	}
+-	return 1;
+-}
+-
+ /*
+  * Main program for the ssh client.
+  */
+@@ -888,9 +851,9 @@ main(int ac, char **av)
+ 			}
+ 			if (options.proxy_command != NULL)
+ 				fatal("Cannot specify -J with ProxyCommand");
+-			if (parse_jump(optarg, &options, 1) == -1)
++			if (parse_jump(optarg, &options, 1, 1) == -1)
++
+ 				fatal("Invalid -J argument");
+-			options.proxy_command = xstrdup("none");
+ 			break;
+ 		case 't':
+ 			if (options.request_tty == REQUEST_TTY_YES)
+@@ -1139,7 +1102,7 @@ main(int ac, char **av)
+ 	if (!host)
+ 		usage();
+ 
+-	if (!valid_hostname(host))
++	if (!ssh_valid_hostname(host))
+ 		fatal("hostname contains invalid characters");
+ 	host_arg = xstrdup(host);
+ 
+@@ -1299,7 +1262,8 @@ main(int ac, char **av)
+ 			sshbin = "ssh";
+ 
+ 		/* Consistency check */
+-		if (options.proxy_command != NULL)
++		if (options.proxy_command != NULL &&
++		    strcasecmp(options.proxy_command, "none") != 0)
+ 			fatal("inconsistent options: ProxyCommand+ProxyJump");
+ 		/* Never use FD passing for ProxyJump */
+ 		options.proxy_use_fdpass = 0;
+@@ -1423,7 +1387,7 @@ main(int ac, char **av)
+ 	 * Conversely, usernames from getpwnam(3) or specified as literals
+ 	 * via configuration are not subject to validation.
+ 	 */
+-	if (user_on_commandline && !valid_ruser(options.user))
++	if (user_on_commandline && !ssh_valid_ruser(options.user))
+ 		fatal("remote username contains invalid characters");
+ 
+ 	/*

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-02.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-02.patch
@@ -1,0 +1,51 @@
+From 1df09b3e69a9505f245c31651ac009d2a5bac323 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:50:55 +0000
+Subject: [PATCH] upstream: move username validity check for usernames
+ specified on
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+the commandline to earlier in main(), specifically before some contexts where
+a username with shell characters might be expanded by a %u directive in
+ssh_config.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We continue to recommend against using untrusted input on
+the SSH commandline. Mitigations like this are not 100%
+guarantees of safety because we can't control every
+combination of user shell and configuration where they are
+used.
+
+Reported by Florian Kohnhäuser
+
+OpenBSD-Commit-ID: 25ef72223f5ccf1c38d307ae77c23c03f59acc55
+
+CVE: CVE-2026-35386
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/76685c9b09a66435cd2ad8373246adf1c53976d3]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ ssh.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/ssh.c b/ssh.c
+index 7d6fa9259..35b694f33 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -1102,6 +1102,12 @@ main(int ac, char **av)
+ 	if (!host)
+ 		usage();
+ 
++	/*
++	 * Validate commandline-specified values that end up in %tokens
++	 * before they are used in config parsing.
++	 */
++	if (options.user != NULL && !ssh_valid_ruser(options.user))
++		fatal("remote username contains invalid characters");
+ 	if (!ssh_valid_hostname(host))
+ 		fatal("hostname contains invalid characters");
+
+ 	host_arg = xstrdup(host);

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-03.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-03.patch
@@ -1,0 +1,25 @@
+From c14af889a8861da208c05ff9fe5d39b75dd3c2a0 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:52:15 +0000
+Subject: [PATCH] upstream: adapt to username validity check change
+
+OpenBSD-Regress-ID: d22c66ca60f0d934a75e6ca752c4c11b9f4a5324
+
+Change-Id: Ieaaf35619abeabf3f771982ab25f6aa81d8e4a11
+CVE: CVE-2026-35386
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/5aa09926fbf050d484a79717fadec8360c5c5645]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ regress/percent.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/regress/percent.sh b/regress/percent.sh
+index fd48156fe..699fa7124 100644
+--- a/regress/percent.sh
++++ b/regress/percent.sh
+@@ -150,4 +150,4 @@ ${SSH} -F $OBJ/ssh_proxy -G "${FOO}@somehost" && fail "user-at expanded env"
+ 
+ # Literal control characters in config is acceptable
+ verbose $tid user control-literal
+-trial user "$FOO" "$FOO"
++#trial user "$FOO" "$FOO"

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35387.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35387.patch
@@ -1,0 +1,137 @@
+From bea09f5eeef5e8daf6d733ede649628282ca276e Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:48:13 +0000
+Subject: [PATCH] upstream: correctly match ECDSA signature algorithms against
+
+algorithm allowlists: HostKeyAlgorithms, PubkeyAcceptedAlgorithms and
+HostbasedAcceptedAlgorithms.
+
+Previously, if any ECDSA type (say "ecdsa-sha2-nistp521") was
+present in one of these lists, then all ECDSA algorithms would
+be permitted.
+
+Reported by Christos Papakonstantinou of Cantina and Spearbit.
+
+OpenBSD-Commit-ID: c790e2687c35989ae34a00e709be935c55b16a86
+
+[cjwatson: Committed upstream together with apparently-unrelated changes
+for CVE-2026-35414.  I've split them into separate patches for clarity.]
+
+Origin: backport, https://anongit.mindrot.org/openssh.git/commit/?id=fd1c7e131f331942d20f42f31e79912d570081fa
+Bug-Debian: https://bugs.debian.org/1132574
+Last-Update: 2026-05-03
+
+Patch-Name: CVE-2026-35387.patch
+
+CVE: CVE-2026-35387
+Upstream-Status: Backport [https://salsa.debian.org/ssh-team/openssh/-/commit/42a8064f37b82f65d3124eddafd078850132354a]
+Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+---
+ auth2-hostbased.c |  7 ++++---
+ auth2-pubkey.c    |  7 ++++---
+ sshconnect2.c     | 26 +++++++++++++++++---------
+ 3 files changed, 25 insertions(+), 15 deletions(-)
+
+diff --git a/auth2-hostbased.c b/auth2-hostbased.c
+index 36b9d2f5b..6882a4f0f 100644
+--- a/auth2-hostbased.c
++++ b/auth2-hostbased.c
+@@ -96,9 +96,10 @@ userauth_hostbased(struct ssh *ssh, const char *method)
+ 		error_f("cannot decode key: %s", pkalg);
+ 		goto done;
+ 	}
+-	if (key->type != pktype) {
+-		error_f("type mismatch for decoded key "
+-		    "(received %d, expected %d)", key->type, pktype);
++	if (key->type != pktype || (sshkey_type_plain(pktype) == KEY_ECDSA &&
++	    sshkey_ecdsa_nid_from_name(pkalg) != key->ecdsa_nid)) {
++		error_f("key type mismatch for decoded key "
++		    "(received %s, expected %s)", sshkey_ssh_name(key), pkalg);
+ 		goto done;
+ 	}
+ 	if (sshkey_type_plain(key->type) == KEY_RSA &&
+diff --git a/auth2-pubkey.c b/auth2-pubkey.c
+index 9c2298fc8..fbab6bd3a 100644
+--- a/auth2-pubkey.c
++++ b/auth2-pubkey.c
+@@ -150,9 +150,10 @@ userauth_pubkey(struct ssh *ssh, const char *method)
+ 		error_f("cannot decode key: %s", pkalg);
+ 		goto done;
+ 	}
+-	if (key->type != pktype) {
+-		error_f("type mismatch for decoded key "
+-		    "(received %d, expected %d)", key->type, pktype);
++	if (key->type != pktype || (sshkey_type_plain(pktype) == KEY_ECDSA &&
++	    sshkey_ecdsa_nid_from_name(pkalg) != key->ecdsa_nid)) {
++		error_f("key type mismatch for decoded key "
++		    "(received %s, expected %s)", sshkey_ssh_name(key), pkalg);
+ 		goto done;
+ 	}
+ 	if (sshkey_type_plain(key->type) == KEY_RSA &&
+diff --git a/sshconnect2.c b/sshconnect2.c
+index 6cfae2af0..491ec5fce 100644
+--- a/sshconnect2.c
++++ b/sshconnect2.c
+@@ -92,10 +92,15 @@ extern Options options;
+ static char *xxx_host;
+ static struct sockaddr *xxx_hostaddr;
+ static const struct ssh_conn_info *xxx_conn_info;
++static int key_type_allowed(struct sshkey *, const char *);
+ 
+ static int
+ verify_host_key_callback(struct sshkey *hostkey, struct ssh *ssh)
+ {
++	if (!key_type_allowed(hostkey, options.hostkeyalgorithms)) {
++		fatal("Server host key %s not in HostKeyAlgorithms",
++		    sshkey_ssh_name(hostkey));
++	}
+ 	if (verify_host_key(xxx_host, xxx_hostaddr, hostkey,
+ 	    xxx_conn_info) != 0)
+ 		fatal("Host key verification failed.");
+@@ -1615,34 +1620,37 @@ load_identity_file(Identity *id)
+ }
+ 
+ static int
+-key_type_allowed_by_config(struct sshkey *key)
++key_type_allowed(struct sshkey *key, const char *allowlist)
+ {
+-	if (match_pattern_list(sshkey_ssh_name(key),
+-	    options.pubkey_accepted_algos, 0) == 1)
++	if (match_pattern_list(sshkey_ssh_name(key), allowlist, 0) == 1)
+ 		return 1;
+ 
+ 	/* RSA keys/certs might be allowed by alternate signature types */
+ 	switch (key->type) {
+ 	case KEY_RSA:
+-		if (match_pattern_list("rsa-sha2-512",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		if (match_pattern_list("rsa-sha2-512", allowlist, 0) == 1)
+ 			return 1;
+-		if (match_pattern_list("rsa-sha2-256",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		if (match_pattern_list("rsa-sha2-256", allowlist, 0) == 1)
+ 			return 1;
+ 		break;
+ 	case KEY_RSA_CERT:
+ 		if (match_pattern_list("rsa-sha2-512-cert-v01@openssh.com",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		    allowlist, 0) == 1)
+ 			return 1;
+ 		if (match_pattern_list("rsa-sha2-256-cert-v01@openssh.com",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		    allowlist, 0) == 1)
+ 			return 1;
+ 		break;
+ 	}
+ 	return 0;
+ }
+ 
++static int
++key_type_allowed_by_config(struct sshkey *key)
++{
++	return key_type_allowed(key, options.pubkey_accepted_algos);
++}
++
+ /* obtain a list of keys from the agent */
+ static int
+ get_agent_identities(struct ssh *ssh, int *agent_fdp,

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -3,5 +3,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI:append = " \
     file://CVE-2025-61984-tests.patch \
     file://CVE-2026-35385.patch \
+    file://CVE-2026-35387.patch \
     "
-

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -2,4 +2,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI:append = " \
     file://CVE-2025-61984-tests.patch \
+    file://CVE-2026-35385.patch \
     "
+

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -4,4 +4,7 @@ SRC_URI:append = " \
     file://CVE-2025-61984-tests.patch \
     file://CVE-2026-35385.patch \
     file://CVE-2026-35387.patch \
+    file://CVE-2026-35386-01.patch \
+    file://CVE-2026-35386-02.patch \
+    file://CVE-2026-35386-03.patch \
     "

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI:append = " \
+    file://CVE-2025-61984-tests.patch \
+    "


### PR DESCRIPTION
Fix the following CVEs -
CVE-2025-61984 CVE-2026-35385 CVE-2026-35387 CVE-2026-35386
source is mainly the patch files from: debian/openssh 1:9.2p1-2+deb12u10
For some CVEs the debian patch files could not be applied, backported same patches from upstream instead.