### PR TITLE
core: linux: Add updated kernels

### DIFF
--- a/meta-core/recipes-kernel/linux/linux-yocto-rt_5.10.bb
+++ b/meta-core/recipes-kernel/linux/linux-yocto-rt_5.10.bb
@@ -1,0 +1,49 @@
+KBRANCH ?= "v5.10/standard/preempt-rt/base"
+
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/linux-yocto.inc
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/cve-exclusion_5.10.inc
+
+# Skip processing of this recipe if it is not explicitly specified as the
+# PREFERRED_PROVIDER for virtual/kernel. This avoids errors when trying
+# to build multiple virtual/kernel providers, e.g. as dependency of
+# core-image-rt-sdk, core-image-rt.
+python () {
+    if d.getVar("KERNEL_PACKAGE_NAME") == "kernel" and d.getVar("PREFERRED_PROVIDER_virtual/kernel") != "linux-yocto-rt":
+        raise bb.parse.SkipRecipe("Set PREFERRED_PROVIDER_virtual/kernel to linux-yocto-rt to enable it")
+}
+
+SRCREV_machine ?= "ffac2f938d5be10761ff7143ec797b0f3ab2bbf0"
+SRCREV_meta ?= "cdb0a7664caa4bd92eb5fb746e4497b0cf16d8c7"
+
+SRC_URI = "git://git.yoctoproject.org/linux-yocto.git;protocol=https;branch=${KBRANCH};name=machine \
+           git://git.yoctoproject.org/yocto-kernel-cache;protocol=https;type=kmeta;name=meta;branch=yocto-5.10;destsuffix=${KMETA}"
+
+LINUX_VERSION ?= "5.10.260"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
+DEPENDS += "openssl-native util-linux-native"
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+KMETA = "kernel-meta"
+KCONF_BSP_AUDIT_LEVEL = "1"
+
+LINUX_KERNEL_TYPE = "preempt-rt"
+
+COMPATIBLE_MACHINE = "^(qemux86|qemux86-64|qemuarm|qemuarmv5|qemuarm64|qemuppc|qemumips)$"
+
+# nooelint: oelint.vars.mispell
+KERNEL_DEVICETREE:qemuarmv5 = "versatile-pb.dtb"
+
+# Functionality flags
+KERNEL_EXTRA_FEATURES ?= "features/netfilter/netfilter.scc features/taskstats/taskstats.scc"
+KERNEL_FEATURES:append = " ${KERNEL_EXTRA_FEATURES}"
+KERNEL_FEATURES:append:qemuall = " cfg/virtio.scc features/drm-bochs/drm-bochs.scc"
+KERNEL_FEATURES:append:qemux86 = " cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append:qemux86-64 = " cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", "features/scsi/scsi-debug.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", "features/gpio/mockup.scc", "", d)}"

--- a/meta-core/recipes-kernel/linux/linux-yocto-rt_5.15.bb
+++ b/meta-core/recipes-kernel/linux/linux-yocto-rt_5.15.bb
@@ -1,0 +1,49 @@
+KBRANCH ?= "v5.15/standard/preempt-rt/base"
+
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/linux-yocto.inc
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/cve-exclusion_5.15.inc
+
+# Skip processing of this recipe if it is not explicitly specified as the
+# PREFERRED_PROVIDER for virtual/kernel. This avoids errors when trying
+# to build multiple virtual/kernel providers, e.g. as dependency of
+# core-image-rt-sdk, core-image-rt.
+python () {
+    if d.getVar("KERNEL_PACKAGE_NAME") == "kernel" and d.getVar("PREFERRED_PROVIDER_virtual/kernel") != "linux-yocto-rt":
+        raise bb.parse.SkipRecipe("Set PREFERRED_PROVIDER_virtual/kernel to linux-yocto-rt to enable it")
+}
+
+SRCREV_machine ?= "c2b76c49319e8e8a776cc3bb4028bcc840a03286"
+SRCREV_meta ?= "73e7c4ea36642d31ee39ec35ab6b5cf55f139ed1"
+
+SRC_URI = "git://git.yoctoproject.org/linux-yocto.git;protocol=https;branch=${KBRANCH};name=machine \
+           git://git.yoctoproject.org/yocto-kernel-cache;protocol=https;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=${KMETA}"
+
+LINUX_VERSION ?= "5.15.211"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
+DEPENDS += "openssl-native util-linux-native"
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+KMETA = "kernel-meta"
+KCONF_BSP_AUDIT_LEVEL = "1"
+
+LINUX_KERNEL_TYPE = "preempt-rt"
+
+COMPATIBLE_MACHINE = "^(qemux86|qemux86-64|qemuarm|qemuarmv5|qemuarm64|qemuppc|qemumips)$"
+
+# nooelint: oelint.vars.mispell
+KERNEL_DEVICETREE:qemuarmv5 = "versatile-pb.dtb"
+
+# Functionality flags
+KERNEL_EXTRA_FEATURES ?= "features/netfilter/netfilter.scc features/taskstats/taskstats.scc"
+KERNEL_FEATURES:append = " ${KERNEL_EXTRA_FEATURES}"
+KERNEL_FEATURES:append:qemuall = " cfg/virtio.scc features/drm-bochs/drm-bochs.scc"
+KERNEL_FEATURES:append:qemux86 = " cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append:qemux86-64 = " cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", "features/scsi/scsi-debug.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", "features/gpio/mockup.scc", "", d)}"

--- a/meta-core/recipes-kernel/linux/linux-yocto-tiny_5.10.bb
+++ b/meta-core/recipes-kernel/linux/linux-yocto-tiny_5.10.bb
@@ -1,0 +1,36 @@
+KBRANCH ?= "v5.10/standard/tiny/base"
+KBRANCH:qemuarm ?= "v5.10/standard/tiny/arm-versatile-926ejs"
+
+LINUX_KERNEL_TYPE = "tiny"
+KCONFIG_MODE = "--allnoconfig"
+
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/linux-yocto.inc
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/cve-exclusion_5.10.inc
+
+LINUX_VERSION ?= "5.10.260"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
+DEPENDS += "openssl-native util-linux-native"
+
+KMETA = "kernel-meta"
+KCONF_BSP_AUDIT_LEVEL = "2"
+
+SRCREV_machine:qemuarm ?= "7c2242c9afe5e886d046062ec30d81991b43a02e"
+SRCREV_machine ?= "b5ab1aa85c9fd114131ab3b8c7528a2d38bad5f7"
+SRCREV_meta ?= "cdb0a7664caa4bd92eb5fb746e4497b0cf16d8c7"
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+SRC_URI = "git://git.yoctoproject.org/linux-yocto.git;protocol=https;branch=${KBRANCH};name=machine \
+           git://git.yoctoproject.org/yocto-kernel-cache;protocol=https;type=kmeta;name=meta;branch=yocto-5.10;destsuffix=${KMETA}"
+
+COMPATIBLE_MACHINE = "^(qemux86|qemux86-64|qemuarm|qemuarmv5)$"
+
+# Functionality flags
+KERNEL_FEATURES = ""
+
+# nooelint: oelint.vars.mispell
+KERNEL_DEVICETREE:qemuarmv5 = "versatile-pb.dtb"

--- a/meta-core/recipes-kernel/linux/linux-yocto-tiny_5.15.bb
+++ b/meta-core/recipes-kernel/linux/linux-yocto-tiny_5.15.bb
@@ -1,0 +1,34 @@
+KBRANCH ?= "v5.15/standard/tiny/base"
+
+LINUX_KERNEL_TYPE = "tiny"
+KCONFIG_MODE = "--allnoconfig"
+
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/linux-yocto.inc
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/cve-exclusion_5.15.inc
+
+LINUX_VERSION ?= "5.15.211"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
+DEPENDS += "openssl-native util-linux-native"
+
+KMETA = "kernel-meta"
+KCONF_BSP_AUDIT_LEVEL = "2"
+
+SRCREV_machine ?= "79899f86224c7a024d144ffe6b66edbc0b7fe122"
+SRCREV_meta ?= "73e7c4ea36642d31ee39ec35ab6b5cf55f139ed1"
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+SRC_URI = "git://git.yoctoproject.org/linux-yocto.git;protocol=https;branch=${KBRANCH};name=machine \
+           git://git.yoctoproject.org/yocto-kernel-cache;protocol=https;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=${KMETA}"
+
+COMPATIBLE_MACHINE = "^(qemux86|qemux86-64|qemuarm64|qemuarm|qemuarmv5)$"
+
+# Functionality flags
+KERNEL_FEATURES = ""
+
+# nooelint: oelint.vars.mispell
+KERNEL_DEVICETREE:qemuarmv5 = "versatile-pb.dtb"

--- a/meta-core/recipes-kernel/linux/linux-yocto_5.10.bb
+++ b/meta-core/recipes-kernel/linux/linux-yocto_5.10.bb
@@ -1,0 +1,63 @@
+KBRANCH ?= "v5.10/standard/base"
+
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/linux-yocto.inc
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/cve-exclusion_5.10.inc
+
+# board specific branches
+KBRANCH:qemuarm ?= "v5.10/standard/arm-versatile-926ejs"
+KBRANCH:qemuarm64 ?= "v5.10/standard/qemuarm64"
+KBRANCH:qemumips ?= "v5.10/standard/mti-malta32"
+KBRANCH:qemuppc ?= "v5.10/standard/qemuppc"
+KBRANCH:qemuriscv64 ?= "v5.10/standard/base"
+KBRANCH:qemuriscv32 ?= "v5.10/standard/base"
+KBRANCH:qemux86 ?= "v5.10/standard/base"
+KBRANCH:qemux86-64 ?= "v5.10/standard/base"
+KBRANCH:qemumips64 ?= "v5.10/standard/mti-malta64"
+
+SRCREV_machine:qemuarm ?= "3be4a87b18adbb7b600c46f1544b663402ab504c"
+SRCREV_machine:qemuarm64 ?= "25eca3b5ff1826eef4da6785d78dcd08c0f50450"
+SRCREV_machine:qemumips ?= "0819ea880e6dc59fdbae66811e6ebd6bdd0751ed"
+SRCREV_machine:qemuppc ?= "9c2e71cac268469b496ac5791d85ba2accc235eb"
+SRCREV_machine:qemuriscv64 ?= "211f1d49424743b389ba218998208cca23777132"
+SRCREV_machine:qemuriscv32 ?= "211f1d49424743b389ba218998208cca23777132"
+SRCREV_machine:qemux86 ?= "211f1d49424743b389ba218998208cca23777132"
+SRCREV_machine:qemux86-64 ?= "211f1d49424743b389ba218998208cca23777132"
+SRCREV_machine:qemumips64 ?= "3ea857a9e76bb0221dfd445156f6638789cfb951"
+SRCREV_machine ?= "211f1d49424743b389ba218998208cca23777132"
+SRCREV_meta ?= "cdb0a7664caa4bd92eb5fb746e4497b0cf16d8c7"
+
+SRC_URI = "git://git.yoctoproject.org/linux-yocto.git;protocol=https;name=machine;branch=${KBRANCH}; \
+           git://git.yoctoproject.org/yocto-kernel-cache;protocol=https;type=kmeta;name=meta;branch=yocto-5.10;destsuffix=${KMETA}"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+LINUX_VERSION ?= "5.10.260"
+
+DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
+DEPENDS += "openssl-native util-linux-native"
+# nooelint: oelint.vars.dependsordered
+DEPENDS += "gmp-native libmpc-native"
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+KMETA = "kernel-meta"
+KCONF_BSP_AUDIT_LEVEL = "1"
+
+# nooelint: oelint.vars.mispell
+KERNEL_DEVICETREE:qemuarmv5 = "versatile-pb.dtb"
+
+COMPATIBLE_MACHINE = "^(qemuarm|qemuarmv5|qemuarm64|qemux86|qemuppc|qemuppc64|qemumips|qemumips64|qemux86-64|qemuriscv64|qemuriscv32)$"
+
+# Functionality flags
+KERNEL_EXTRA_FEATURES ?= "features/netfilter/netfilter.scc"
+KERNEL_FEATURES:append = " ${KERNEL_EXTRA_FEATURES}"
+KERNEL_FEATURES:append:qemuall = " cfg/virtio.scc features/drm-bochs/drm-bochs.scc"
+KERNEL_FEATURES:append:qemux86 = " cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append:qemux86-64 = " cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append:powerpc = " arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append:powerpc64 = " arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append:powerpc64le = " arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("TUNE_FEATURES", "mx32", " cfg/x32.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/scsi/scsi-debug.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/gpio/mockup.scc", "", d)}"

--- a/meta-core/recipes-kernel/linux/linux-yocto_5.15.bb
+++ b/meta-core/recipes-kernel/linux/linux-yocto_5.15.bb
@@ -1,0 +1,76 @@
+KBRANCH ?= "v5.15/standard/base"
+
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/linux-yocto.inc
+# nooelint: oelint.file.requirenotfound
+require recipes-kernel/linux/cve-exclusion_5.15.inc
+
+# board specific branches
+KBRANCH:qemuarm ?= "v5.15/standard/arm-versatile-926ejs"
+KBRANCH:qemuarm64 ?= "v5.15/standard/qemuarm64"
+KBRANCH:qemumips ?= "v5.15/standard/mti-malta32"
+KBRANCH:qemuppc ?= "v5.15/standard/qemuppc"
+KBRANCH:qemuriscv64 ?= "v5.15/standard/base"
+KBRANCH:qemuriscv32 ?= "v5.15/standard/base"
+KBRANCH:qemux86 ?= "v5.15/standard/base"
+KBRANCH:qemux86-64 ?= "v5.15/standard/base"
+KBRANCH:qemumips64 ?= "v5.15/standard/mti-malta64"
+
+SRCREV_machine:qemuarm ?= "da60e1f132b1a0a3dbcbf6ae5c4fe23ebe1d5524"
+SRCREV_machine:qemuarm64 ?= "e3ab4c73da88d36e404b7dfc1d64ba2342036b97"
+SRCREV_machine:qemumips ?= "3b284cd01a6f211fa4637f54faddb93bf4bccf2b"
+SRCREV_machine:qemuppc ?= "57a955956279c3d61a28a2d8317418577935f7c7"
+SRCREV_machine:qemuriscv64 ?= "18e4624f98c9b6be454ec3081fd2d9344f607393"
+SRCREV_machine:qemuriscv32 ?= "18e4624f98c9b6be454ec3081fd2d9344f607393"
+SRCREV_machine:qemux86 ?= "18e4624f98c9b6be454ec3081fd2d9344f607393"
+SRCREV_machine:qemux86-64 ?= "18e4624f98c9b6be454ec3081fd2d9344f607393"
+SRCREV_machine:qemumips64 ?= "e65770335eb7badc2db9212ae90afc029a5ffdba"
+SRCREV_machine ?= "18e4624f98c9b6be454ec3081fd2d9344f607393"
+SRCREV_meta ?= "73e7c4ea36642d31ee39ec35ab6b5cf55f139ed1"
+
+# set your preferred provider of linux-yocto to 'linux-yocto-upstream', and you'll
+# get the <version>/base branch, which is pure upstream -stable, and the same
+# meta SRCREV as the linux-yocto-standard builds. Select your version using the
+# normal PREFERRED_VERSION settings.
+BBCLASSEXTEND = "devupstream:target"
+SRCREV_machine:class-devupstream ?= "c86c4726e7f044ab73b493c6f00527aafef640cd"
+PN:class-devupstream = "linux-yocto-upstream"
+KBRANCH:class-devupstream = "v5.15/base"
+
+SRC_URI = "git://git.yoctoproject.org/linux-yocto.git;protocol=https;name=machine;branch=${KBRANCH}; \
+           git://git.yoctoproject.org/yocto-kernel-cache;protocol=https;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=${KMETA}"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+LINUX_VERSION ?= "5.15.211"
+
+DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
+DEPENDS += "openssl-native util-linux-native"
+# nooelint: oelint.vars.dependsordered
+DEPENDS += "gmp-native libmpc-native"
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+KMETA = "kernel-meta"
+KCONF_BSP_AUDIT_LEVEL = "1"
+
+# nooelint: oelint.vars.mispell
+KERNEL_DEVICETREE:qemuarmv5 = "versatile-pb.dtb"
+
+COMPATIBLE_MACHINE = "^(qemuarm|qemuarmv5|qemuarm64|qemux86|qemuppc|qemuppc64|qemumips|qemumips64|qemux86-64|qemuriscv64|qemuriscv32)$"
+
+# Functionality flags
+KERNEL_EXTRA_FEATURES ?= "features/netfilter/netfilter.scc"
+KERNEL_FEATURES:append = " ${KERNEL_EXTRA_FEATURES}"
+KERNEL_FEATURES:append:qemuall = " cfg/virtio.scc features/drm-bochs/drm-bochs.scc"
+KERNEL_FEATURES:append:qemux86 = " cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append:qemux86-64 = " cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("TUNE_FEATURES", "mx32", " cfg/x32.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/scsi/scsi-debug.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/gpio/mockup.scc", "", d)}"
+KERNEL_FEATURES:append:powerpc = " arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append:powerpc64 = " arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append:powerpc64le = " arch/powerpc/powerpc-debug.scc"
+
+# nooelint: oelint.vars.insaneskip
+INSANE_SKIP:kernel-vmlinux:qemuppc64 = "textrel"
+

--- a/scripts/get-bitbake-targets.py
+++ b/scripts/get-bitbake-targets.py
@@ -97,10 +97,10 @@ def get_bpns(
         List[str]: All BPNs in the layer, or all associated BPNs if modified files are provided
     """
     bpns = get_modified_bpns(modified_files) if modified_files else get_all_bpns()
-
-    # We never want Systemd in the list of bpns
-    if "systemd" in bpns:
-        bpns.remove("systemd")
+    
+    bpns = list(set(bpns))  # Remove duplicates
+    bpns = list(filter(lambda bpn: bpn != "systemd", bpns))
+    bpns = list(filter(lambda bpn: not bpn.startswith("linux-yocto"), bpns))
 
     if bpn_filter == BPNFilter.NATIVE:
         return list(


### PR DESCRIPTION
Adds 5.10 and 5.15 kernels with the latest patch versions. Pulled from poky-contrib zedd/kernel-kirkstone 06725820.
https://git.yoctoproject.org/poky-contrib/commit/?h=zedd/kernel-kirkstone&id=06725820be30f3797533a27d21e6b3ae4b10e591