### PR TITLE
 core: mesa: backport fixes for CVE-2026-40393

### DIFF
--- a/meta-core/recipes-graphics/mesa/files/CVE-2026-40393-01.patch
+++ b/meta-core/recipes-graphics/mesa/files/CVE-2026-40393-01.patch
@@ -1,0 +1,125 @@
+From d9b05cf92e71784eb773294ec1f11c1feac749c2 Mon Sep 17 00:00:00 2001
+From: Paulo Zanoni <paulo.r.zanoni@intel.com>
+Date: Mon, 18 Mar 2024 16:33:54 -0700
+Subject: [PATCH 1/4] vulkan: don't zero-initialize STACK_ARRAY()'s stack array
+
+STACK_ARRAY() is used in a lot of places. When games are running we
+see STACK_ARRAY() arrays being used all the time: each queue
+submission uses 6, WaitSemaphores and syncobj waiting also uses them:
+they're constantly present in Vulkan runtime.
+
+There's no need for STACK_ARRAY()'s stack array to be initialized,
+callers cannot not depend on it. If the number of elements is greater
+than STACK_ARRAY_SIZE, then STACK_ARRAY() will just malloc() the array
+and return it not initialized: anybody depending of
+zero-initialization is going to break when the array is big.
+
+The reason why we're zero-intializing STACK_ARRAY()'s stack array is
+to silence -Wmaybe-uninitialized warnings: see commit d7957df31848
+("vulkan: fix uninitialized variables"). I don't think that commit is
+the ideal way to deal with the problem, so this patch proposes a
+better solution.
+
+The problem here is that zero-initializing it adds code we don't need
+for every single caller. STACK_ARRAY() already has 63 callers and only
+3 of them are affected by the -Wmaybe-uninitialized warining. So here
+we undo what commit d7957df31848 did and instead we fix the 3 cases
+that actually generate the -Wmaybe-uninitialized warnings.
+
+Gcc is only emitting those warinings because it knows that the number
+of elements in the array may be zero, so the loops we have that set
+elements to the array may end up do nothing, and then we pass the
+array uninitialized to other functions.
+
+For the cases related to vk_sync this is just returning VK_SUCCESS
+earlier, instead of relying on the check that eventually happens at
+__vk_sync_wait_many(). For the vkCmdWaitEvents() function, the Vulkan
+spec says that "eventCount must be greater than 0", so the early
+return doesn't hurt anybody either. In both cases we make the zero
+case faster by not defining an 8-sized array, zero-initializing it,
+then returning success without using it.
+
+Reference: d7957df31848 ("vulkan: fix uninitialized variables")
+Acked-by: Yonggang Luo <luoyonggang@gmail.com>
+Reviewed-by: Yiwei Zhang <zzyiwei@chromium.org>
+Signed-off-by: Paulo Zanoni <paulo.r.zanoni@intel.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/28288>
+CVE: CVE-2026-40393
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/b0653370d0ea7d6c72cd419451debed52e09653d]
+Signed-off-by: Micah Shennum <micah.shennum@garmin.com>
+---
+ src/vulkan/runtime/vk_queue.c            |  4 ++++
+ src/vulkan/runtime/vk_sync_binary.c      |  3 +++
+ src/vulkan/runtime/vk_synchronization2.c |  3 +++
+ src/vulkan/util/vk_util.h                | 11 +++++++++--
+ 4 files changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/src/vulkan/runtime/vk_queue.c b/src/vulkan/runtime/vk_queue.c
+index 9aef3e9505d..1741f90f142 100644
+--- a/src/vulkan/runtime/vk_queue.c
++++ b/src/vulkan/runtime/vk_queue.c
+@@ -1004,6 +1004,10 @@ vk_queue_wait_before_present(struct vk_queue *queue,
+       return VK_SUCCESS;
+ 
+    const uint32_t wait_count = pPresentInfo->waitSemaphoreCount;
++
++   if (wait_count == 0)
++      return VK_SUCCESS;
++
+    STACK_ARRAY(struct vk_sync_wait, waits, wait_count);
+ 
+    for (uint32_t i = 0; i < wait_count; i++) {
+diff --git a/src/vulkan/runtime/vk_sync_binary.c b/src/vulkan/runtime/vk_sync_binary.c
+index 3d2720f9348..c10cabe348a 100644
+--- a/src/vulkan/runtime/vk_sync_binary.c
++++ b/src/vulkan/runtime/vk_sync_binary.c
+@@ -91,6 +91,9 @@ vk_sync_binary_wait_many(struct vk_device *device,
+                          enum vk_sync_wait_flags wait_flags,
+                          uint64_t abs_timeout_ns)
+ {
++   if (wait_count == 0)
++      return VK_SUCCESS;
++
+    STACK_ARRAY(struct vk_sync_wait, timeline_waits, wait_count);
+ 
+    for (uint32_t i = 0; i < wait_count; i++) {
+diff --git a/src/vulkan/runtime/vk_synchronization2.c b/src/vulkan/runtime/vk_synchronization2.c
+index 621bc2f36d1..437a394dfee 100644
+--- a/src/vulkan/runtime/vk_synchronization2.c
++++ b/src/vulkan/runtime/vk_synchronization2.c
+@@ -208,6 +208,9 @@ vk_common_CmdWaitEvents(
+    VK_FROM_HANDLE(vk_command_buffer, cmd_buffer, commandBuffer);
+    struct vk_device *device = cmd_buffer->base.device;
+ 
++   if (eventCount == 0)
++      return;
++
+    STACK_ARRAY(VkDependencyInfoKHR, deps, eventCount);
+ 
+    /* Note that dstStageMask and srcStageMask in the CmdWaitEvent2() call
+diff --git a/src/vulkan/util/vk_util.h b/src/vulkan/util/vk_util.h
+index 386e9e469f0..28687b2ef9c 100644
+--- a/src/vulkan/util/vk_util.h
++++ b/src/vulkan/util/vk_util.h
+@@ -281,9 +281,16 @@ vk_spec_info_to_nir_spirv(const VkSpecializationInfo *spec_info,
+ 
+ #define STACK_ARRAY_SIZE 8
+ 
++/* Sometimes gcc may claim -Wmaybe-uninitialized for the stack array in some
++ * places it can't verify that when size is 0 nobody down the call chain reads
++ * the array. Please don't try to fix it by zero-initializing the array here
++ * since it's used in a lot of different places. An "if (size == 0) return;"
++ * may work for you.
++ */
+ #define STACK_ARRAY(type, name, size) \
+-   type _stack_##name[STACK_ARRAY_SIZE] = {0}, *const name = \
+-      (size) <= STACK_ARRAY_SIZE ? _stack_##name : malloc((size) * sizeof(type))
++   type _stack_##name[STACK_ARRAY_SIZE]; \
++   type *const name = \
++     ((size) <= STACK_ARRAY_SIZE ? _stack_##name : (type *)malloc((size) * sizeof(type)))
+ 
+ #define STACK_ARRAY_FINISH(name) \
+    if (name != _stack_##name) free(name)
+-- 
+2.54.0
+

--- a/meta-core/recipes-graphics/mesa/files/CVE-2026-40393-02.patch
+++ b/meta-core/recipes-graphics/mesa/files/CVE-2026-40393-02.patch
@@ -1,0 +1,121 @@
+From af271f669db138b1a6ab1e794890404932eaddc6 Mon Sep 17 00:00:00 2001
+From: Faith Ekstrand <faith.ekstrand@collabora.com>
+Date: Tue, 29 Jul 2025 03:10:41 -0400
+Subject: [PATCH 2/4] util: Move STACK_ARRAY into util
+
+It's useful for more than just Vulkan.
+
+Reviewed-by: Boris Brezillon <boris.brezillon@collabora.com>
+Reviewed-by: Christoph Pillmayer <christoph.pillmayer@arm.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/36385>
+CVE: CVE-2026-40393
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/f43cff3728e58c377d1e03b13db62514217abfe1]
+Signed-off-by: Micah Shennum <micah.shennum@garmin.com>
+---
+ src/util/meson.build      |  1 +
+ src/util/stack_array.h    | 45 +++++++++++++++++++++++++++++++++++++++
+ src/vulkan/util/vk_util.h | 17 +--------------
+ 3 files changed, 47 insertions(+), 16 deletions(-)
+ create mode 100644 src/util/stack_array.h
+
+diff --git a/src/util/meson.build b/src/util/meson.build
+index 6e77a2f0364..9c379727cc5 100644
+--- a/src/util/meson.build
++++ b/src/util/meson.build
+@@ -110,6 +110,7 @@ files_mesa_util = files(
+   'softfloat.h',
+   'sparse_array.c',
+   'sparse_array.h',
++  'stack_array.h',
+   'string_buffer.c',
+   'string_buffer.h',
+   'strndup.h',
+diff --git a/src/util/stack_array.h b/src/util/stack_array.h
+new file mode 100644
+index 00000000000..e2133bdc2f4
+--- /dev/null
++++ b/src/util/stack_array.h
+@@ -0,0 +1,45 @@
++/*
++ * Copyright © 2025 Collabora, Ltd.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a
++ * copy of this software and associated documentation files (the "Software"),
++ * to deal in the Software without restriction, including without limitation
++ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
++ * and/or sell copies of the Software, and to permit persons to whom the
++ * Software is furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice (including the next
++ * paragraph) shall be included in all copies or substantial portions of the
++ * Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
++ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
++ * IN THE SOFTWARE.
++ */
++
++#include <stdlib.h>
++
++#ifndef UTIL_STACK_ARRAY_H
++#define UTIL_STACK_ARRAY_H
++
++#define STACK_ARRAY_SIZE 8
++
++/* Sometimes gcc may claim -Wmaybe-uninitialized for the stack array in some
++ * places it can't verify that when size is 0 nobody down the call chain reads
++ * the array. Please don't try to fix it by zero-initializing the array here
++ * since it's used in a lot of different places. An "if (size == 0) return;"
++ * may work for you.
++ */
++#define STACK_ARRAY(type, name, size) \
++   type _stack_##name[STACK_ARRAY_SIZE]; \
++   type *const name = \
++     ((size) <= STACK_ARRAY_SIZE ? _stack_##name : (type *)malloc((size) * sizeof(type)))
++
++#define STACK_ARRAY_FINISH(name) \
++   if (name != _stack_##name) free(name)
++
++#endif /* UTIL_STACK_ARRAY_H */
+diff --git a/src/vulkan/util/vk_util.h b/src/vulkan/util/vk_util.h
+index 28687b2ef9c..b840fcf78bc 100644
+--- a/src/vulkan/util/vk_util.h
++++ b/src/vulkan/util/vk_util.h
+@@ -25,6 +25,7 @@
+ 
+ #include "util/bitscan.h"
+ #include "util/macros.h"
++#include "util/stack_array.h"
+ #include "compiler/shader_enums.h"
+ #include <stdlib.h>
+ #include <string.h>
+@@ -279,22 +280,6 @@ struct nir_spirv_specialization*
+ vk_spec_info_to_nir_spirv(const VkSpecializationInfo *spec_info,
+                           uint32_t *out_num_spec_entries);
+ 
+-#define STACK_ARRAY_SIZE 8
+-
+-/* Sometimes gcc may claim -Wmaybe-uninitialized for the stack array in some
+- * places it can't verify that when size is 0 nobody down the call chain reads
+- * the array. Please don't try to fix it by zero-initializing the array here
+- * since it's used in a lot of different places. An "if (size == 0) return;"
+- * may work for you.
+- */
+-#define STACK_ARRAY(type, name, size) \
+-   type _stack_##name[STACK_ARRAY_SIZE]; \
+-   type *const name = \
+-     ((size) <= STACK_ARRAY_SIZE ? _stack_##name : (type *)malloc((size) * sizeof(type)))
+-
+-#define STACK_ARRAY_FINISH(name) \
+-   if (name != _stack_##name) free(name)
+-
+ #ifdef __cplusplus
+ }
+ #endif
+-- 
+2.54.0
+

--- a/meta-core/recipes-graphics/mesa/files/CVE-2026-40393-03.patch
+++ b/meta-core/recipes-graphics/mesa/files/CVE-2026-40393-03.patch
@@ -1,0 +1,56 @@
+From 78110488b7d699098e214a6f0ed9a04710274ba4 Mon Sep 17 00:00:00 2001
+From: Ian Romanick <ian.d.romanick@intel.com>
+Date: Fri, 23 Jan 2026 10:07:27 -0800
+Subject: [PATCH 3/4] nir: Use STACK_ARRAY instead of NIR_VLA
+
+The number of fields comes from the shader, so it could be a value large
+enough that using alloca would be problematic.
+
+Fixes: c11833ab24d ("nir,spirv: Rework function calls")
+Reviewed-by: Caio Oliveira <caio.oliveira@intel.com>
+Reviewed-by: Ryan Neph <ryanneph@google.com>
+Reviewed-by: Lionel Landwerlin <lionel.g.landwerlin@intel.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/39866>
+CVE: CVE-2026-40393
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/9017d37e84771f921a63676dd8b955df9ef20f29]
+Comment: Function was in a different file and had to be manually located
+Signed-off-by: Micah Shennum <micah.shennum@garmin.com>
+---
+ src/compiler/nir/nir_inline_functions.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/compiler/nir/nir_inline_functions.c b/src/compiler/nir/nir_inline_functions.c
+index eba53d06029..c289ad7a876 100644
+--- a/src/compiler/nir/nir_inline_functions.c
++++ b/src/compiler/nir/nir_inline_functions.c
+@@ -21,10 +21,10 @@
+  * IN THE SOFTWARE.
+  */
+ 
++#include "util/stack_array.h"
+ #include "nir.h"
+ #include "nir_builder.h"
+ #include "nir_control_flow.h"
+-#include "nir_vla.h"
+ 
+ static bool function_ends_in_jump(nir_function_impl *impl)
+ {
+@@ -159,13 +159,14 @@ inline_functions_block(nir_block *block, nir_builder *b,
+        * to an SSA value first.
+        */
+       const unsigned num_params = call->num_params;
+-      NIR_VLA(nir_ssa_def *, params, num_params);
++      STACK_ARRAY(nir_ssa_def *, params, num_params);
+       for (unsigned i = 0; i < num_params; i++) {
+          params[i] = nir_ssa_for_src(b, call->params[i],
+                                      call->callee->params[i].num_components);
+       }
+ 
+       nir_inline_function_impl(b, call->callee->impl, params, NULL);
++      STACK_ARRAY_FINISH(params);
+    }
+ 
+    return progress;
+-- 
+2.54.0
+

--- a/meta-core/recipes-graphics/mesa/files/CVE-2026-40393-04.patch
+++ b/meta-core/recipes-graphics/mesa/files/CVE-2026-40393-04.patch
@@ -1,0 +1,102 @@
+From e2a4e2f3b960c0dd31a2a19f8eb731e540adf203 Mon Sep 17 00:00:00 2001
+From: Ian Romanick <ian.d.romanick@intel.com>
+Date: Fri, 23 Jan 2026 09:58:26 -0800
+Subject: [PATCH 4/4] spirv: Use STACK_ARRAY instead of NIR_VLA
+
+The number of fields comes from the shader, so it could be a value large
+enough that using alloca would be problematic.
+
+Fixes: 2a023f30a64 ("nir/spirv: Add basic support for types")
+Reviewed-by: Caio Oliveira <caio.oliveira@intel.com>
+Reviewed-by: Ryan Neph <ryanneph@google.com>
+Reviewed-by: Lionel Landwerlin <lionel.g.landwerlin@intel.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/39866>
+CVE: CVE-2026-40393
+Upstream-Status: Backport [https://gitlab.freedesktop.org/mesa/mesa/-/commit/3da828d2dd12e20ba2afc152db8d7236c7a48c13]
+Signed-off-by: Micah Shennum <micah.shennum@garmin.com>
+---
+ src/compiler/spirv/spirv_to_nir.c | 27 +++++++++++++++++----------
+ 1 file changed, 17 insertions(+), 10 deletions(-)
+
+diff --git a/src/compiler/spirv/spirv_to_nir.c b/src/compiler/spirv/spirv_to_nir.c
+index 79e176a2218..2914c077671 100644
+--- a/src/compiler/spirv/spirv_to_nir.c
++++ b/src/compiler/spirv/spirv_to_nir.c
+@@ -26,13 +26,13 @@
+  */
+ 
+ #include "vtn_private.h"
+-#include "nir/nir_vla.h"
+ #include "nir/nir_control_flow.h"
+ #include "nir/nir_constant_expressions.h"
+ #include "nir/nir_deref.h"
+ #include "spirv_info.h"
+ 
+ #include "util/format/u_format.h"
++#include "util/stack_array.h"
+ #include "util/u_math.h"
+ #include "util/u_string.h"
+ 
+@@ -926,7 +926,7 @@ vtn_type_get_nir_type(struct vtn_builder *b, struct vtn_type *type,
+       case vtn_base_type_struct: {
+          bool need_new_struct = false;
+          const uint32_t num_fields = type->length;
+-         NIR_VLA(struct glsl_struct_field, fields, num_fields);
++         STACK_ARRAY(struct glsl_struct_field, fields, num_fields);
+          for (unsigned i = 0; i < num_fields; i++) {
+             fields[i] = *glsl_get_struct_field_data(type->type, i);
+             const struct glsl_type *field_nir_type =
+@@ -936,20 +936,25 @@ vtn_type_get_nir_type(struct vtn_builder *b, struct vtn_type *type,
+                need_new_struct = true;
+             }
+          }
++
++         const struct glsl_type *result;
+          if (need_new_struct) {
+             if (glsl_type_is_interface(type->type)) {
+-               return glsl_interface_type(fields, num_fields,
+-                                          /* packing */ 0, false,
+-                                          glsl_get_type_name(type->type));
++               result = glsl_interface_type(fields, num_fields,
++                                            /* packing */ 0, false,
++                                            glsl_get_type_name(type->type));
+             } else {
+-               return glsl_struct_type(fields, num_fields,
+-                                       glsl_get_type_name(type->type),
+-                                       glsl_struct_type_is_packed(type->type));
++               result = glsl_struct_type(fields, num_fields,
++                                         glsl_get_type_name(type->type),
++                                         glsl_struct_type_is_packed(type->type));
+             }
+          } else {
+             /* No changes, just pass it on */
+-            return type->type;
++            result = type->type;
+          }
++
++         STACK_ARRAY_FINISH(fields);
++         return result;
+       }
+ 
+       case vtn_base_type_image:
+@@ -1519,7 +1524,7 @@ vtn_handle_type(struct vtn_builder *b, SpvOp opcode,
+       val->type->offsets = ralloc_array(b, unsigned, num_fields);
+       val->type->packed = false;
+ 
+-      NIR_VLA(struct glsl_struct_field, fields, count);
++      STACK_ARRAY(struct glsl_struct_field, fields, count);
+       for (unsigned i = 0; i < num_fields; i++) {
+          val->type->members[i] = vtn_get_type(b, w[i + 2]);
+          const char *name = NULL;
+@@ -1575,6 +1580,8 @@ vtn_handle_type(struct vtn_builder *b, SpvOp opcode,
+                                             name ? name : "struct",
+                                             val->type->packed);
+       }
++
++      STACK_ARRAY_FINISH(fields);
+       break;
+    }
+ 
+-- 
+2.54.0
+

--- a/meta-core/recipes-graphics/mesa/mesa_22.0.3.bbappend
+++ b/meta-core/recipes-graphics/mesa/mesa_22.0.3.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://CVE-2026-40393-01.patch \
+    file://CVE-2026-40393-02.patch \
+    file://CVE-2026-40393-03.patch \
+    file://CVE-2026-40393-04.patch \
+    "


### PR DESCRIPTION
Backport the needed patches for
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/39866/ as well as a couple of patches needed to support the fix.