### PR TITLE
core: libinput: ignore CVE-2026-35094

### DIFF
--- a/meta-core/recipes-graphics/wayland/libinput_1.15.2.bbappend
+++ b/meta-core/recipes-graphics/wayland/libinput_1.15.2.bbappend
@@ -1,4 +1,4 @@
 # cpe-incorrect:
 # The lua plugin was not even added until 1.29.901~96, therefore this CVE does
 # not apply to our version and we can safely ignore it.
-CVE_CHECK_WHITELIST += "CVE-2026-35093"
+CVE_CHECK_WHITELIST += "CVE-2026-35093 CVE-2026-35094"


### PR DESCRIPTION
Adds CVE-2026-35094 to CVE_CHECK_WHITELIST since the problematic code does not exist in the codebase at version 1.15.2. The lua plugin was not even introduced until 1.29.901~96.