### PR TITLE
Backport CVE fixes for glib-2.0

### DIFF
--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58010.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58010.patch
@@ -1,0 +1,113 @@
+From 2755cfb3cfba517d8ca924a50f39e8f8c7074177 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Sun, 29 Mar 2026 19:10:41 +0100
+Subject: [PATCH] gvariant: Fix an off-by-one error in an offset comparison
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This allows a single byte out-of-bounds read off the end of the
+(potentially untrusted) byte array backing a `GVariant` when it’s
+being checked for normal form.
+
+I can’t see how this could practically be exploited, but it’s certainly
+a security bug as the `GVariant` normal form checking code is supposed
+to be robust to malicious inputs.
+
+Spotted by linhlhq as #YWH-PGM9867-190, and fix and reproducer provided
+by them too, thanks. Confirmed and turned into a unit test by me.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Fixes: #3915
+
+CVE: CVE-2026-58010
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/8338414f6560216efe67d3cbf549e32f8630252a]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ glib/gvariant-serialiser.c |  2 +-
+ glib/tests/gvariant.c      | 48 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 49 insertions(+), 1 deletion(-)
+
+diff --git a/glib/gvariant-serialiser.c b/glib/gvariant-serialiser.c
+index 4e50ed752..7889822fe 100644
+--- a/glib/gvariant-serialiser.c
++++ b/glib/gvariant-serialiser.c
+@@ -1238,7 +1238,7 @@ gvs_tuple_is_normal (GVariantSerialised value)
+ 
+       while (offset & alignment)
+         {
+-          if (offset > value.size || value.data[offset] != '\0')
++          if (offset >= value.size || value.data[offset] != '\0')
+             return FALSE;
+           offset++;
+         }
+diff --git a/glib/tests/gvariant.c b/glib/tests/gvariant.c
+index 2eca8be88..083e8c9a6 100644
+--- a/glib/tests/gvariant.c
++++ b/glib/tests/gvariant.c
+@@ -5493,6 +5493,52 @@ test_normal_checking_tuple_offsets5 (void)
+   g_variant_unref (variant);
+ }
+ 
++/* This is a regression test that looping over the padding bytes in a short
++ * (non-normal) tuple doesn’t overflow the input data.
++ *
++ * See https://gitlab.gnome.org/GNOME/glib/-/issues/3915 */
++static void
++test_normal_checking_tuple_offsets6 (void)
++{
++  /*
++   * Type: (ynqiuxthdsog) — 12 members, first member 'y' (byte) has
++   * alignment 0, second 'n' (int16) has alignment 1.
++   * With 1 byte of data (0x28), after reading the first byte member,
++   * offset=1, alignment check for 'n' requires offset to be even,
++   * so the while loop checks value.data[1] — but size is only 1.
++   *
++   * Use heap allocation via GBytes so ASan reports heap-buffer-overflow.
++   */
++  guint8 *heap_data = NULL;
++  GBytes *bytes = NULL;
++  const GVariantType *data_type = G_VARIANT_TYPE ("(ynqiuxthdsog)");
++  GVariant *variant = NULL;
++  GVariant *normal_variant = NULL;
++  GVariant *expected = NULL;
++
++  g_test_bug ("https://gitlab.gnome.org/GNOME/glib/-/issues/3915");
++
++  heap_data = g_malloc (1);
++  heap_data[0] = 0x28;
++  bytes = g_bytes_new_take (heap_data, 1);
++
++  variant = g_variant_new_from_bytes (data_type, bytes, FALSE);
++  g_assert_nonnull (variant);
++
++  g_assert_false (g_variant_is_normal_form (variant));
++
++  normal_variant = g_variant_get_normal_form (variant);
++  g_assert_nonnull (normal_variant);
++
++  expected = g_variant_new_parsed ("(byte 0x28, int16 0, uint16 0, 0, uint32 0, int64 0, uint64 0, handle 0, 0.0, '', objectpath '/', signature '')");
++  g_assert_cmpvariant (expected, variant);
++  g_assert_cmpvariant (expected, normal_variant);
++
++  g_variant_unref (expected);
++  g_variant_unref (normal_variant);
++  g_variant_unref (variant);
++}
++
+ /* Test that an otherwise-valid serialised GVariant is considered non-normal if
+  * its offset table entries are too wide.
+  *
+@@ -5743,6 +5789,8 @@ main (int argc, char **argv)
+                    test_normal_checking_tuple_offsets4);
+   g_test_add_func ("/gvariant/normal-checking/tuple-offsets5",
+                    test_normal_checking_tuple_offsets5);
++  g_test_add_func ("/gvariant/normal-checking/tuple-offsets6",
++                   test_normal_checking_tuple_offsets6);
+   g_test_add_func ("/gvariant/normal-checking/tuple-offsets/minimal-sized",
+                    test_normal_checking_tuple_offsets_minimal_sized);
+   g_test_add_func ("/gvariant/normal-checking/empty-object-path",
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58011-01.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58011-01.patch
@@ -1,0 +1,61 @@
+From dcc59b24df150a3bf2c12d2caa367d60ac4d55f2 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Sun, 29 Mar 2026 23:19:47 +0100
+Subject: [PATCH 1/2] gdatetime: Factor out a couple of magic constants
+
+This introduces no functional changes, it just makes the code a little
+clearer.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+CVE: CVE-2026-58011
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/7f0f7d0870dad0dd0584c380fe699dfb5006db60]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ glib/gdatetime.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/glib/gdatetime.c b/glib/gdatetime.c
+index f8bf31c43..d2e27a303 100644
+--- a/glib/gdatetime.c
++++ b/glib/gdatetime.c
+@@ -124,7 +124,7 @@ struct _GDateTime
+   gint interval;
+ 
+   /* 1 is 0001-01-01 in Proleptic Gregorian */
+-  gint32 days;
++  gint32 days;  /* in range [MIN_DAYS, MAX_DAYS] */
+ 
+   volatile gint ref_count;
+ };
+@@ -166,6 +166,9 @@ struct _GDateTime
+ #define JULIAN_YEAR(d)       ((d)->julian / 365.25)
+ #define DAYS_PER_PERIOD      (G_GINT64_CONSTANT (2914695))
+ 
++#define MIN_DAYS 1  /* the days count for 0001-01-01 in Proleptic Gregorian */
++#define MAX_DAYS 3652059  /* the days count for 9999-12-31 in Proleptic Gregorian */
++
+ static const guint16 days_in_months[2][13] =
+ {
+   { 0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 },
+@@ -775,7 +778,7 @@ g_date_time_from_instant (GTimeZone *tz,
+   datetime->days = instant / USEC_PER_DAY;
+   datetime->usec = instant % USEC_PER_DAY;
+ 
+-  if (datetime->days < 1 || 3652059 < datetime->days)
++  if (datetime->days < MIN_DAYS || datetime->days > MAX_DAYS)
+     {
+       g_date_time_unref (datetime);
+       datetime = NULL;
+@@ -811,7 +814,7 @@ g_date_time_deal_with_date_change (GDateTime *datetime)
+   gint64 full_time;
+   gint64 usec;
+ 
+-  if (datetime->days < 1 || datetime->days > 3652059)
++  if (datetime->days < MIN_DAYS || datetime->days > MAX_DAYS)
+     return FALSE;
+ 
+   was_dst = g_time_zone_is_dst (datetime->tz, datetime->interval);
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58011-02.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58011-02.patch
@@ -1,0 +1,74 @@
+From 03c6da7d05203194f1bf35bc43483f86b87c8148 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Sun, 29 Mar 2026 23:46:17 +0100
+Subject: [PATCH 2/2] gdatetime: Add missing range validation to
+ g_date_time_add_full()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Otherwise it’s possible to create a non-`NULL` but invalid `GDateTime`,
+which breaks all kinds of internal assumptions.
+
+Spotted by linhlhq as #YWH-PGM9867-191. Thanks to them for providing a
+suggested fix and a test case, which I have adapted and validated.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Fixes: #3917
+
+CVE: CVE-2026-58011
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/ededb77ea01bfbb321402d85da4342af4379cfd4]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ glib/gdatetime.c       |  4 +++-
+ glib/tests/gdatetime.c | 18 ++++++++++++++++++
+ 2 files changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/glib/gdatetime.c b/glib/gdatetime.c
+index d2e27a303..49c330119 100644
+--- a/glib/gdatetime.c
++++ b/glib/gdatetime.c
+@@ -2006,7 +2006,9 @@ g_date_time_add_full (GDateTime *datetime,
+   new->days = full_time / USEC_PER_DAY;
+   new->usec = full_time % USEC_PER_DAY;
+ 
+-  /* XXX validate */
++  /* Validate it’s still in the range 0001-01-01 to 9999-12-31 */
++  if (new->days < MIN_DAYS || new->days > MAX_DAYS)
++    g_clear_pointer (&new, g_date_time_unref);
+ 
+   return new;
+ }
+diff --git a/glib/tests/gdatetime.c b/glib/tests/gdatetime.c
+index 2f0be3104..ec36aff74 100644
+--- a/glib/tests/gdatetime.c
++++ b/glib/tests/gdatetime.c
+@@ -1049,6 +1049,24 @@ test_GDateTime_add_full (void)
+   TEST_ADD_FULL (2010,  8, 25, 22, 45, 0,
+                     0,  1,  6,  1, 25, 0,
+                  2010, 10,  2,  0, 10, 0);
++
++#define TEST_ADD_FULL_ERROR(y,m,d,h,mi,s,ay,am,ad,ah,ami,as) G_STMT_START { \
++  GDateTime *dt; \
++  dt = g_date_time_new_utc (y, m, d, h, mi, s); \
++  g_assert_null (g_date_time_add_full (dt, ay, am, ad, ah, ami, as)); \
++  g_date_time_unref (dt); \
++} G_STMT_END
++
++  TEST_ADD_FULL_ERROR (     1, 12,  1,  0,  0, 0,
++                           -1,  0,  0,  0,  0, 0);
++  TEST_ADD_FULL_ERROR (     1, 12,  1,  0,  0, 0,
++                        10000,  0,  0,  0,  0, 0);
++  TEST_ADD_FULL_ERROR (  9999, 12,  1,  0,  0, 0,
++                       -10000,  0,  0,  0,  0, 0);
++  TEST_ADD_FULL_ERROR (     1, 12,  1,  0,  0, 0,
++                            0,  0, 3660001,  0,  0, 0);
++  TEST_ADD_FULL_ERROR (  9999, 12,  1,  0,  0, 0,
++                            0,  0, -3660001,  0,  0, 0);
+ }
+ 
+ static void
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58013.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58013.patch
@@ -1,0 +1,48 @@
+From 0feac1ccdf269df04b0fa0948d5cb860ed6784d5 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Tue, 28 Apr 2026 16:45:14 +0100
+Subject: [PATCH] giochannel: Fix memcmp() off the end of the buffer with long
+ terminators
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If the line terminator is longer than a single byte, and the current
+line extends to the end of the buffer, and the buffer (which is a
+`GString`) is near a power of two in length (as that’s how `GString`s
+are allocated) it’s possible for the `memcmp()` which checks the
+terminator to read off the end of the string buffer.
+
+Fix that by checking the terminator length against the last character
+before calling `memcmp()`. Add a unit test.
+
+Spotted by linhlhq as #YWH-PGM9867-199. The fix is theirs (validated by
+me), and the unit test is adapted from their proof of concept.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+Fixes: #3925
+
+CVE: CVE-2026-58013
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/6a2583dec39bfe05553b16d9b7419d6c2a257244]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ glib/giochannel.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/glib/giochannel.c b/glib/giochannel.c
+index 936722c12..c2f115427 100644
+--- a/glib/giochannel.c
++++ b/glib/giochannel.c
+@@ -1819,7 +1819,8 @@ read_again:
+         {
+           if (channel->line_term)
+             {
+-              if (memcmp (channel->line_term, nextchar, line_term_len) == 0)
++              if ((size_t) (lastchar - nextchar) >= line_term_len &&
++                  memcmp (channel->line_term, nextchar, line_term_len) == 0)
+                 {
+                   line_length = nextchar - use_buf->str;
+                   got_term_len = line_term_len;
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58014.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58014.patch
@@ -1,0 +1,110 @@
+From 16550f9c56d17b113b9146024b2c36df5700aba6 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Sat, 11 Apr 2026 14:42:57 +0100
+Subject: [PATCH] gkeyfile: Fix a one-byte heap under-read with
+ g_key_file_get_locale_string_list()
+
+If this method was called on a key file key which has an empty value,
+`len == 0` and this leads to a one-byte under-read off the start of the
+key file buffer.
+
+Spotted by linhlhq as #YWH-PGM9867-200. The suggested fix is theirs, and
+the unit test is adapted from their report. I added the fuzzing test.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Fixes: #3930
+
+CVE: CVE-2026-58014
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/5f6d86b50bebf5458ab1becf4de2c5e5f066122b]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ fuzzing/fuzz_key.c   |  9 +++++++++
+ glib/gkeyfile.c      |  2 +-
+ glib/tests/keyfile.c | 23 +++++++++++++++++++++++
+ 3 files changed, 33 insertions(+), 1 deletion(-)
+
+diff --git a/fuzzing/fuzz_key.c b/fuzzing/fuzz_key.c
+index 8d0edc5fa..e4e76239f 100644
+--- a/fuzzing/fuzz_key.c
++++ b/fuzzing/fuzz_key.c
+@@ -4,6 +4,8 @@ int
+ LLVMFuzzerTestOneInput (const unsigned char *data, size_t size)
+ {
+   GKeyFile *key = NULL;
++  char *comment = NULL;
++  char **list = NULL;
+ 
+   fuzz_set_logging_func ();
+ 
+@@ -11,6 +13,13 @@ LLVMFuzzerTestOneInput (const unsigned char *data, size_t size)
+   g_key_file_load_from_data (key, (const gchar*) data, size, G_KEY_FILE_NONE,
+                              NULL);
+ 
++  /* Also try some additional parsing and see if it crashes */
++  comment = g_key_file_get_comment (key, "group", "key", NULL);
++  g_free (comment);
++
++  list = g_key_file_get_locale_string_list (key, "group", "key", "de", NULL, NULL);
++  g_strfreev (list);
++
+   g_key_file_free (key);
+   return 0;
+ }
+diff --git a/glib/gkeyfile.c b/glib/gkeyfile.c
+index e486f6928..dfa8e6416 100644
+--- a/glib/gkeyfile.c
++++ b/glib/gkeyfile.c
+@@ -2396,7 +2396,7 @@ g_key_file_get_locale_string_list (GKeyFile     *key_file,
+     }
+ 
+   len = strlen (value);
+-  if (value[len - 1] == key_file->list_separator)
++  if (len > 0 && value[len - 1] == key_file->list_separator)
+     value[len - 1] = '\0';
+ 
+   list_separator[0] = key_file->list_separator;
+diff --git a/glib/tests/keyfile.c b/glib/tests/keyfile.c
+index ccbdadd56..6a5f011f9 100644
+--- a/glib/tests/keyfile.c
++++ b/glib/tests/keyfile.c
+@@ -758,6 +758,28 @@ test_locale_string (void)
+   g_free (old_locale);
+ }
+ 
++static void
++test_locale_string_empty (void)
++{
++  GKeyFile *keyfile = NULL;
++  GError *local_error = NULL;
++  const char *data =
++    "[valid]\n"
++    "key1=\n";
++
++  g_test_summary ("Check that loading an empty translatable string works");
++  g_test_bug ("https://gitlab.gnome.org/GNOME/glib/-/issues/3930");
++
++  keyfile = g_key_file_new ();
++
++  g_key_file_load_from_data (keyfile, data, -1, G_KEY_FILE_NONE, &local_error);
++  g_assert_no_error (local_error);
++
++  check_locale_string_list_value (keyfile, "valid", "key1", NULL, NULL);
++
++  g_key_file_free (keyfile);
++}
++
+ static void
+ test_lists (void)
+ {
+@@ -1788,6 +1810,7 @@ main (int argc, char *argv[])
+   g_test_add_func ("/keyfile/boolean", test_boolean);
+   g_test_add_func ("/keyfile/number", test_number);
+   g_test_add_func ("/keyfile/locale-string", test_locale_string);
++  g_test_add_func ("/keyfile/locale-string/empty", test_locale_string_empty);
+   g_test_add_func ("/keyfile/lists", test_lists);
+   g_test_add_func ("/keyfile/lists-set-get", test_lists_set_get);
+   g_test_add_func ("/keyfile/group-remove", test_group_remove);
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015.patch
@@ -1,0 +1,85 @@
+From 428460f9db0462a866c808c1464030e1e52bcc58 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Tue, 28 Apr 2026 15:47:30 +0100
+Subject: [PATCH] gdbusauthmechanismsha1: Validate cookie context
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Without validation, the server could send a malicious context which
+contains path traversal characters, allowing it to exfiltrate a SHA-1
+hashed copy of arbitrary data from the client’s file system.
+
+To exploit this successfully would require the client to choose to
+connect peer-to-peer to a malicious D-Bus server and to choose the SHA-1
+authentication mechanism in preference to all the other mechanisms. This
+is vanishingly unlikely.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Fixes: #3931
+
+CVE: CVE-2026-58015
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/8b72ad09c874ddff122b3e67b3470c5e2eab7690]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ gio/gdbusauthmechanismsha1.c | 36 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
+
+diff --git a/gio/gdbusauthmechanismsha1.c b/gio/gdbusauthmechanismsha1.c
+index 2754d3c2b..9354ceadc 100644
+--- a/gio/gdbusauthmechanismsha1.c
++++ b/gio/gdbusauthmechanismsha1.c
+@@ -1104,6 +1104,34 @@ mechanism_client_initiate (GDBusAuthMechanism   *mechanism,
+   return initial_response;
+ }
+ 
++/* Context names must be valid ASCII, nonzero length, and may not contain the
++ * characters slash ("/"), backslash ("\"), space (" "), newline ("\n"),
++ * carriage return ("\r"), tab ("\t"), or period (".").
++ *
++ * See https://dbus.freedesktop.org/doc/dbus-specification.html#auth-mechanisms-sha */
++static gboolean
++validate_cookie_context (const char *cookie_context)
++{
++  size_t i = 0;
++
++  g_return_val_if_fail (cookie_context != NULL, FALSE);
++
++  for (i = 0; cookie_context[i] != '\0'; i++)
++    {
++      if ((guint8) cookie_context[i] >= 128 ||
++          cookie_context[i] == '/' ||
++          cookie_context[i] == '\\' ||
++          cookie_context[i] == ' ' ||
++          cookie_context[i] == '\n' ||
++          cookie_context[i] == '\r' ||
++          cookie_context[i] == '\t' ||
++          cookie_context[i] == '.')
++        return FALSE;
++    }
++
++  return (i > 0);
++}
++
+ static void
+ mechanism_client_data_receive (GDBusAuthMechanism   *mechanism,
+                                const gchar          *data,
+@@ -1138,6 +1166,14 @@ mechanism_client_data_receive (GDBusAuthMechanism   *mechanism,
+     }
+ 
+   cookie_context = tokens[0];
++  if (!validate_cookie_context (tokens[0]))
++    {
++      g_free (m->priv->reject_reason);
++      m->priv->reject_reason = g_strdup_printf ("Malformed cookie_context '%s'", tokens[0]);
++      m->priv->state = G_DBUS_AUTH_MECHANISM_STATE_REJECTED;
++      goto out;
++    }
++
+   cookie_id = g_ascii_strtoll (tokens[1], &endp, 10);
+   if (*endp != '\0')
+     {
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58016-01.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58016-01.patch
@@ -1,0 +1,95 @@
+From 0298f35bed9046be8bcdac8d30ae9efd83c74a01 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Thu, 16 Apr 2026 15:27:37 +0100
+Subject: [PATCH 1/2] gdbusintrospection: Fix XML parser state handling for
+ <node> element nesting
+
+The check for whether a `<node>` element in D-Bus introspection XML was
+nested correctly was broken. `<node>` elements can only be at the top
+level, or nested immediately within another `<node>` element.
+
+Fix the check and add some unit tests for it.
+
+Spotted by linhlhq as #YWH-PGM9867-204. The fix is mine, and the unit test
+uses example XML strings adapted from their report.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Fixes: #3932
+
+CVE: CVE-2026-58016
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/c9da977c178fbfc0e4caf99f9fdf5dc433d6fcc2]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ gio/gdbusintrospection.c        |  2 +-
+ gio/tests/gdbus-introspection.c | 34 +++++++++++++++++++++++++++++++++
+ 2 files changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/gio/gdbusintrospection.c b/gio/gdbusintrospection.c
+index dde06422e..6113d7797 100644
+--- a/gio/gdbusintrospection.c
++++ b/gio/gdbusintrospection.c
+@@ -1270,7 +1270,7 @@ parser_start_element (GMarkupParseContext  *context,
+   /* ---------------------------------------------------------------------------------------------------- */
+   if (strcmp (element_name, "node") == 0)
+     {
+-      if (!(g_slist_length (stack) >= 1 || strcmp (stack->next->data, "node") != 0))
++      if (stack->next != NULL && strcmp (stack->next->data, "node") != 0)
+         {
+           g_set_error_literal (error,
+                                G_MARKUP_ERROR,
+diff --git a/gio/tests/gdbus-introspection.c b/gio/tests/gdbus-introspection.c
+index 50c0cc721..bf5dbb0af 100644
+--- a/gio/tests/gdbus-introspection.c
++++ b/gio/tests/gdbus-introspection.c
+@@ -297,6 +297,39 @@ test_extra_data (void)
+   g_dbus_node_info_unref (info);
+ }
+ 
++static void
++test_invalid (void)
++{
++  const struct
++    {
++      const char *xml;
++      GMarkupError expected_error_code;
++    }
++  vectors[] =
++    {
++      { "", G_MARKUP_ERROR_EMPTY },
++      { "<node><interface name=\"I\"><method name=\"M\"><node><interface name=\"I2\"></interface></node></method>", G_MARKUP_ERROR_INVALID_CONTENT },
++      { "<node><interface name=\"I\"><signal name=\"S\"><node><interface name=\"I2\"><signal name=\"S2\"></signal></interface></node></signal>", G_MARKUP_ERROR_INVALID_CONTENT },
++      { "<node><interface name=\"I\"><property name=\"P\" type=\"s\" access=\"read\"><node><interface name=\"I2\"></interface></node></property>", G_MARKUP_ERROR_INVALID_CONTENT },
++      { "<node><interface name=\"I\"><method name=\"M\"><arg type=\"\"><node><interface name=\"I2\"><method name=\"M2\"></method></interface></node></arg>", G_MARKUP_ERROR_INVALID_CONTENT },
++    };
++  size_t i;
++
++  for (i = 0; i < G_N_ELEMENTS (vectors); i++)
++    {
++      GDBusNodeInfo *node;
++      GError *local_error = NULL;
++
++      g_test_message ("Testing parsing of %s gives an error", vectors[i].xml);
++
++      node = g_dbus_node_info_new_for_xml (vectors[i].xml, &local_error);
++      g_assert_error (local_error, G_MARKUP_ERROR, (int) vectors[i].expected_error_code);
++      g_assert_null (node);
++
++      g_clear_error (&local_error);
++    }
++}
++
+ /* ---------------------------------------------------------------------------------------------------- */
+ 
+ int
+@@ -314,6 +347,7 @@ main (int   argc,
+   g_test_add_func ("/gdbus/introspection-generate", test_generate);
+   g_test_add_func ("/gdbus/introspection-default-direction", test_default_direction);
+   g_test_add_func ("/gdbus/introspection-extra-data", test_extra_data);
++  g_test_add_func ("/gdbus/introspection/invalid", test_invalid);
+ 
+   ret = session_bus_run ();
+ 
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58016-02.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58016-02.patch
@@ -1,0 +1,98 @@
+From dc8bc6973c299b2634ff25a5faa2aadf8a4be439 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Thu, 16 Apr 2026 15:08:10 +0100
+Subject: [PATCH 2/2] gdbusintrospection: Add some assertions before array
+ dereferences
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The state handling inside the D-Bus introspection XML parser is
+complicated, and it’s possible that these dereferences of the
+`len - 1`th element might get reached when the array is empty.
+
+Make failures like that more debuggable by adding an assertion on the
+length beforehand.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Helps: #3932
+
+CVE: CVE-2026-58016
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/656ad4582cb1d7a7fa8bafe3ce8aec6aa3c17da0]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ gio/gdbusintrospection.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/gio/gdbusintrospection.c b/gio/gdbusintrospection.c
+index 6113d7797..25865930e 100644
+--- a/gio/gdbusintrospection.c
++++ b/gio/gdbusintrospection.c
+@@ -1108,6 +1108,7 @@ parse_data_get_annotation (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->annotations, g_new0 (GDBusAnnotationInfo, 1));
++  g_assert (data->annotations->len > 0);
+   return data->annotations->pdata[data->annotations->len - 1];
+ }
+ 
+@@ -1117,6 +1118,7 @@ parse_data_get_arg (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->args, g_new0 (GDBusArgInfo, 1));
++  g_assert (data->args->len > 0);
+   return data->args->pdata[data->args->len - 1];
+ }
+ 
+@@ -1126,6 +1128,7 @@ parse_data_get_out_arg (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->out_args, g_new0 (GDBusArgInfo, 1));
++  g_assert (data->out_args->len > 0);
+   return data->out_args->pdata[data->out_args->len - 1];
+ }
+ 
+@@ -1135,6 +1138,7 @@ parse_data_get_method (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->methods, g_new0 (GDBusMethodInfo, 1));
++  g_assert (data->methods->len > 0);
+   return data->methods->pdata[data->methods->len - 1];
+ }
+ 
+@@ -1144,6 +1148,7 @@ parse_data_get_signal (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->signals, g_new0 (GDBusSignalInfo, 1));
++  g_assert (data->signals->len > 0);
+   return data->signals->pdata[data->signals->len - 1];
+ }
+ 
+@@ -1153,6 +1158,7 @@ parse_data_get_property (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->properties, g_new0 (GDBusPropertyInfo, 1));
++  g_assert (data->properties->len > 0);
+   return data->properties->pdata[data->properties->len - 1];
+ }
+ 
+@@ -1162,6 +1168,7 @@ parse_data_get_interface (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->interfaces, g_new0 (GDBusInterfaceInfo, 1));
++  g_assert (data->interfaces->len > 0);
+   return data->interfaces->pdata[data->interfaces->len - 1];
+ }
+ 
+@@ -1171,6 +1178,7 @@ parse_data_get_node (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->nodes, g_new0 (GDBusNodeInfo, 1));
++  g_assert (data->nodes->len > 0);
+   return data->nodes->pdata[data->nodes->len - 1];
+ }
+ 
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
@@ -30,4 +30,5 @@ SRC_URI_append = " \
     file://CVE-2026-58011-01.patch \
     file://CVE-2026-58011-02.patch \
     file://CVE-2026-58013.patch \
+    file://CVE-2026-58014.patch \
     "

--- a/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
@@ -27,4 +27,6 @@ SRC_URI_append = " \
     file://CVE-2025-14087-03.patch \
     file://CVE-2025-14512.patch \
     file://CVE-2026-58010.patch \
+    file://CVE-2026-58011-01.patch \
+    file://CVE-2026-58011-02.patch \
     "

--- a/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
@@ -26,4 +26,5 @@ SRC_URI_append = " \
     file://CVE-2025-14087-02.patch \
     file://CVE-2025-14087-03.patch \
     file://CVE-2025-14512.patch \
+    file://CVE-2026-58010.patch \
     "

--- a/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
@@ -31,4 +31,5 @@ SRC_URI_append = " \
     file://CVE-2026-58011-02.patch \
     file://CVE-2026-58013.patch \
     file://CVE-2026-58014.patch \
+    file://CVE-2026-58015.patch \
     "

--- a/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
@@ -32,4 +32,6 @@ SRC_URI_append = " \
     file://CVE-2026-58013.patch \
     file://CVE-2026-58014.patch \
     file://CVE-2026-58015.patch \
+    file://CVE-2026-58016-01.patch \
+    file://CVE-2026-58016-02.patch \
     "

--- a/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0_2.62.6.bbappend
@@ -29,4 +29,5 @@ SRC_URI_append = " \
     file://CVE-2026-58010.patch \
     file://CVE-2026-58011-01.patch \
     file://CVE-2026-58011-02.patch \
+    file://CVE-2026-58013.patch \
     "


### PR DESCRIPTION
Backports several CVE fixes for glib-2.0:
* CVE-2026-58010
* CVE-2026-58011
* CVE-2026-58013
* CVE-2026-58014
* CVE-2026-58015
* CVE-2026-58016