### PR TITLE
core: curl: backport fix for CVE-2026-8927 (kirkstone)

### DIFF
--- a/meta-core/recipes-support/curl/curl_7.82.0.bbappend
+++ b/meta-core/recipes-support/curl/curl_7.82.0.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://CVE-2026-8927.patch \
+"

--- a/meta-core/recipes-support/curl/files/CVE-2026-8927.patch
+++ b/meta-core/recipes-support/curl/files/CVE-2026-8927.patch
@@ -1,0 +1,339 @@
+From 4ccded03ad219e1fc5c10a748d04fb58a0adb999 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jo=C3=A3o=20Marcos=20Costa?= <joaomarcos.costa@bootlin.com>
+Date: Wed, 22 Jul 2026 17:25:35 +0200
+Subject: [PATCH] url: detect proxy changes read from environment
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When a proxy is set from an environment variable, detect if that proxy
+is not the same as previously and flush state.
+
+Verified by test1647: verify changing proxy with env variables and make
+sure Digest state is flushed in the second use
+
+Closes #21666
+
+Upstream-Status: Backport [https://github.com/curl/curl/commit/5c225384b8d52c6]
+Signed-off-by: João Marcos Costa (Schneider Electric) <joaomarcos.costa@bootlin.com>
+---
+ lib/url.c                  |  12 ++++
+ lib/urldata.h              |   4 +-
+ tests/data/test1647        | 103 +++++++++++++++++++++++++++++++
+ tests/libtest/Makefile.inc |   4 ++
+ tests/libtest/lib1647.c    | 120 +++++++++++++++++++++++++++++++++++++
+ 5 files changed, 242 insertions(+), 1 deletion(-)
+ create mode 100644 tests/data/test1647
+ create mode 100644 tests/libtest/lib1647.c
+
+diff --git a/lib/url.c b/lib/url.c
+index 0797fb9..09b9923 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -110,6 +110,7 @@ bool curl_win32_idn_to_ascii(const char *in, char **out);
+ #include "telnet.h"
+ #include "tftp.h"
+ #include "http.h"
++#include "vauth/vauth.h"
+ #include "http2.h"
+ #include "file.h"
+ #include "curl_ldap.h"
+@@ -475,6 +476,9 @@ CURLcode Curl_close(struct Curl_easy **datap)
+   Curl_wildcard_dtor(&data->wildcard);
+   Curl_freeset(data);
+   free(data);
++#ifndef CURL_DISABLE_DIGEST_AUTH
++  free(data->state.envproxy);
++#endif
+   return CURLE_OK;
+ }
+ 
+@@ -2781,6 +2785,14 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
+       result = CURLE_UNSUPPORTED_PROTOCOL;
+       goto out;
+ #else
++#ifndef CURL_DISABLE_DIGEST_AUTH
++      if(!Curl_safecmp(data->state.envproxy, proxy)) {
++        /* proxy changed */
++        Curl_auth_digest_cleanup(&data->state.proxydigest);
++        free(data->state.envproxy);
++        data->state.envproxy = Curl_cstrdup(proxy);
++      }
++#endif
+       /* force this connection's protocol to become HTTP if compatible */
+       if(!(conn->handler->protocol & PROTO_FAMILY_HTTP)) {
+         if((conn->handler->flags & PROTOPT_PROXY_AS_HTTP) &&
+diff --git a/lib/urldata.h b/lib/urldata.h
+index d252e73..390ac90 100644
+--- a/lib/urldata.h
++++ b/lib/urldata.h
+@@ -1363,9 +1363,11 @@ struct UrlState {
+   /* storage for the previous bag^H^H^HSIGPIPE signal handler :-) */
+   void (*prev_signal)(int sig);
+ #endif
++#ifndef CURL_DISABLE_DIGEST_AUTH
++  char *envproxy; /* last proxy string used for proxy-related state */
+   struct digestdata digest;      /* state data for host Digest auth */
+   struct digestdata proxydigest; /* state data for proxy Digest auth */
+-
++#endif
+   struct auth authhost;  /* auth details for host */
+   struct auth authproxy; /* auth details for proxy */
+ #ifdef USE_CURL_ASYNC
+diff --git a/tests/data/test1647 b/tests/data/test1647
+new file mode 100644
+index 0000000..a87487f
+--- /dev/null
++++ b/tests/data/test1647
+@@ -0,0 +1,103 @@
++<?xml version="1.0" encoding="US-ASCII"?>
++<testcase>
++<info>
++<keywords>
++HTTP
++HTTP GET
++HTTP proxy
++HTTP proxy Digest auth
++multi
++</keywords>
++</info>
++
++# Server-side
++<reply>
++
++# this is returned first since we get no proxy-auth
++<data crlf="headers" nocheck="yes">
++HTTP/1.1 407 Authorization Required to proxy me my dear
++Proxy-Authenticate: Digest realm="weirdorealm", nonce="12345"
++Content-Length: 33
++
++And you should ignore this data.
++</data>
++
++# then this is returned when we get proxy-auth
++<data1000 crlf="headers">
++HTTP/1.1 200 OK
++Content-Length: 21
++Server: no
++
++Nice proxy auth sir!
++</data1000>
++
++<connect crlf="headers">
++HTTP/1.1 401 OK
++Content-Length: 21
++Server: no
++
++Denied access. Leave
++</connect>
++
++</reply>
++
++# Client-side
++<client>
++<server>
++http
++https-proxy
++https
++</server>
++# tool is what to use instead of 'curl'
++<tool>
++lib%TESTNUMBER
++</tool>
++<features>
++!SSPI
++crypto
++proxy
++digest
++Debug
++</features>
++<setenv>
++http_proxy=%HOSTIP:%HTTPPORT
++https_proxy=https://%HOSTIP:%HTTPSPROXYPORT
++CURL_ENTROPY=99376
++</setenv>
++<name>
++HTTP proxy auth Digest, then change proxy with env var and do it again
++</name>
++<command>
++http://test.remote.example.com/path/%TESTNUMBER https://another.example.com:%HTTPSPORT/ daniel:monkey123 another:bump456
++</command>
++</client>
++
++# Verify data after the test has been "shot"
++<verify>
++<protocol crlf="headers">
++GET http://test.remote.example.com/path/%TESTNUMBER HTTP/1.1
++Host: test.remote.example.com
++Accept: */*
++Proxy-Connection: Keep-Alive
++
++GET http://test.remote.example.com/path/%TESTNUMBER HTTP/1.1
++Host: test.remote.example.com
++Proxy-Authorization: Digest username="daniel", realm="weirdorealm", nonce="12345", uri="/path/%TESTNUMBER", response="7a1672891aff03248887b1a6674b8096"
++Accept: */*
++Proxy-Connection: Keep-Alive
++
++</protocol>
++
++<proxy crlf="headers">
++CONNECT another.example.com:%HTTPSPORT HTTP/1.1
++Host: another.example.com:%HTTPSPORT
++Proxy-Connection: Keep-Alive
++
++</proxy>
++
++# CONNECT fails
++<errorcode>
++7
++</errorcode>
++</verify>
++</testcase>
+diff --git a/tests/libtest/Makefile.inc b/tests/libtest/Makefile.inc
+index 8721d55..f8603eb 100644
+--- a/tests/libtest/Makefile.inc
++++ b/tests/libtest/Makefile.inc
+@@ -59,6 +59,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
+  lib1550 lib1551 lib1552 lib1553 lib1554 lib1555 lib1556 lib1557 \
+  lib1558 lib1559 lib1560 lib1564 lib1565 lib1567 lib1568 lib1569 \
+  lib1591 lib1592 lib1593 lib1594 lib1596 \
++ lib1647 \
+          lib1905 lib1906 lib1907 lib1908 lib1910 lib1911 lib1912 lib1913 \
+          lib1915 lib1916 lib1917 lib1918 lib1933 lib1934 lib1935 lib1936 \
+  lib1937 lib1938 lib1939 \
+@@ -647,6 +648,9 @@ lib1593_LDADD = $(TESTUTIL_LIBS)
+ lib1594_SOURCES = lib1594.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+ lib1594_LDADD = $(TESTUTIL_LIBS)
+ 
++lib1647_SOURCES = lib1647.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
++lib1647_LDADD = $(TESTUTIL_LIBS)
++
+ lib1596_SOURCES = lib1594.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+ lib1596_LDADD = $(TESTUTIL_LIBS)
+ lib1596_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1596
+diff --git a/tests/libtest/lib1647.c b/tests/libtest/lib1647.c
+new file mode 100644
+index 0000000..8060e1b
+--- /dev/null
++++ b/tests/libtest/lib1647.c
+@@ -0,0 +1,120 @@
++/***************************************************************************
++ *                                  _   _ ____  _
++ *  Project                     ___| | | |  _ \| |
++ *                             / __| | | | |_) | |
++ *                            | (__| |_| |  _ <| |___
++ *                             \___|\___/|_| \_\_____|
++ *
++ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
++ *
++ * This software is licensed as described in the file COPYING, which
++ * you should have received as part of this distribution. The terms
++ * are also available at https://curl.se/docs/copyright.html.
++ *
++ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
++ * copies of the Software, and permit persons to whom the Software is
++ * furnished to do so, under the terms of the COPYING file.
++ *
++ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
++ * KIND, either express or implied.
++ *
++ * SPDX-License-Identifier: curl
++ *
++ ***************************************************************************/
++/*
++ * argv1 = the first URL
++ * argv2 = URL2
++ * argv3 = credentials 1
++ * argv4 = credentials 2
++ */
++
++#include "first.h"
++
++/* this is meant to pick up the proxy from the environment variable */
++static CURLcode init1647(CURL *curl, const char *url, const char *userpwd)
++{
++  CURLcode result = CURLE_OK;
++
++  res_easy_setopt(curl, CURLOPT_URL, url);
++  if(result)
++    goto init_failed;
++
++  res_easy_setopt(curl, CURLOPT_PROXYUSERPWD, userpwd);
++  if(result)
++    goto init_failed;
++
++  res_easy_setopt(curl, CURLOPT_PROXYAUTH, CURLAUTH_DIGEST);
++  if(result)
++    goto init_failed;
++
++  res_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
++  if(result)
++    goto init_failed;
++
++  res_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
++  if(result)
++    goto init_failed;
++
++  res_easy_setopt(curl, CURLOPT_PROXY_SSL_VERIFYPEER, 0L);
++  if(result)
++    goto init_failed;
++
++  res_easy_setopt(curl, CURLOPT_PROXY_SSL_VERIFYHOST, 0L);
++  if(result)
++    goto init_failed;
++
++  res_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
++  if(result)
++    goto init_failed;
++
++  return CURLE_OK; /* success */
++
++init_failed:
++  return result; /* failure */
++}
++
++static CURLcode run1647(CURL *curl, const char *url, const char *userpwd)
++{
++  CURLcode result = CURLE_OK;
++
++  result = init1647(curl, url, userpwd);
++  if(result)
++    return result;
++
++  return curl_easy_perform(curl);
++}
++
++static CURLcode test_lib1647(const char *URL)
++{
++  CURLcode result = CURLE_OK;
++  CURL *curl = NULL;
++
++  res_global_init(CURL_GLOBAL_ALL);
++  if(result)
++    return result;
++
++  curl = curl_easy_init();
++  if(!curl) {
++    curl_mfprintf(stderr, "curl_easy_init() failed\n");
++    curl_global_cleanup();
++    return TEST_ERR_MAJOR_BAD;
++  }
++
++  start_test_timing();
++
++  curl_mprintf("--- First get '%s'\n", URL);
++  result = run1647(curl, URL, libtest_arg3);
++  if(result)
++    goto test_cleanup;
++
++  curl_mprintf("--- Then get '%s'\n", libtest_arg2);
++  result = run1647(curl, libtest_arg2, libtest_arg4);
++
++test_cleanup:
++
++  /* proper cleanup sequence - type PB */
++
++  curl_easy_cleanup(curl);
++  curl_global_cleanup();
++  return result;
++}


### PR DESCRIPTION
Hello,

I followed the steps described [here](https://github.com/garmin/meta-lts-collab#building-and-runtime-testing) to test this patch, and the build works correctly. As for the `testimage` step, here are the results:

```
   RESULTS:
   RESULTS - ping.PingTest.test_ping: PASSED (0.02s)
   RESULTS - ptest.PtestRunnerTest.test_ptestrunner_expectsuccess: PASSED (1433.54s)
   RESULTS - ssh.SSHTest.test_ssh: PASSED (0.97s)
   RESULTS - ptest.PtestRunnerTest.test_ptestrunner_expectfail: SKIPPED (0.00s)
   SUMMARY:
   core-image-minimal () - Ran 4 tests in 1434.523s
   core-image-minimal - OK - All required tests passed (successes=3, skipped=1, failures=0, errors=0)
```

The vulnerability is detailed here: https://nvd.nist.gov/vuln/detail/CVE-2026-8927

Best regards,