### PR TITLE
core: libinput:  CVE-2026-35093, CVE-2026-35094, CVE-2026-50292 (kirkstone)

### DIFF
--- a/meta-core/recipes-graphics/wayland/libinput/CVE-2026-50292-01.patch
+++ b/meta-core/recipes-graphics/wayland/libinput/CVE-2026-50292-01.patch
@@ -1,0 +1,106 @@
+From f5d3d0885b99a810d912b8281b95ab311f8a28c9 Mon Sep 17 00:00:00 2001
+From: Peter Hutterer <peter.hutterer@who-t.net>
+Date: Mon, 1 Jun 2026 10:12:29 +1000
+Subject: [PATCH] util: sanitize control characters in str_sanitize()
+
+str_sanitize() only escaped '%' characters for format string safety.
+Device names from uinput devices can contain arbitrary bytes including
+ANSI escape sequences (ESC, 0x1b) and other control characters. When
+these strings are included in log messages and printed to a terminal,
+the escape sequences are interpreted by the terminal emulator. This
+could allow an attacker to manipulate terminal output (change colors,
+set window title, clear screen) when an administrator views libinput
+logs.
+
+Replace all control characters (0x00-0x1f and 0x7f) with '?' in
+addition to the existing '%' escaping. This prevents terminal escape
+sequence injection through device names in log output.
+
+Assisted-by: Claude:claude-opus-4-6
+(cherry picked from commit 71a2c5cae2a80a1e3bb29e3f3a07ccc3f3de5acb)
+
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1489>
+
+CVE: CVE-2026-50292
+Upstream-Status: Backport [https://gitlab.freedesktop.org/libinput/libinput/-/commit/fc2262e1c1847021239065e84f39f15492ef05cc]
+Signed-off-by: Andrej Koehler <andrej.koehler@gmx.net>
+---
+ src/util-strings.h | 28 +++++++++++++++++++++++-----
+ test/test-utils.c  | 10 ++++++++++
+ 2 files changed, 33 insertions(+), 5 deletions(-)
+
+diff --git a/src/util-strings.h b/src/util-strings.h
+index d5a84146..2d609ba8 100644
+--- a/src/util-strings.h
++++ b/src/util-strings.h
+@@ -403,7 +403,10 @@ trunkname(const char *filename);
+ 
+ /**
+  * Return a copy of str with all % converted to %% to make the string
+- * acceptable as printf format.
++ * acceptable as printf format, and all non-NUL control characters
++ * (bytes 0x01-0x1f, 0x7f) replaced with '?' to prevent terminal
++ * escape sequence injection. NUL bytes are excluded implicitly
++ * because the string is null-terminated.
+  */
+ static inline char *
+ str_sanitize(const char *str)
+@@ -411,18 +414,33 @@ str_sanitize(const char *str)
+ 	if (!str)
+ 		return NULL;
+ 
+-	if (!strchr(str, '%'))
++	size_t slen = min(strlen(str), 512);
++
++	bool needs_sanitization = false;
++	for (size_t i = 0; i < slen; i++) {
++		unsigned char c = str[i];
++		if (c == '%' || c < 0x20 || c == 0x7f) {
++			needs_sanitization = true;
++			break;
++		}
++	}
++	if (!needs_sanitization)
+ 		return strdup(str);
+ 
+-	size_t slen = min(strlen(str), 512);
+ 	char *sanitized = zalloc(2 * slen + 1);
+ 	const char *src = str;
+ 	char *dst = sanitized;
+ 
+ 	for (size_t i = 0; i < slen; i++) {
+-		if (*src == '%')
++		unsigned char c = *src++;
++		if (c == '%') {
+ 			*dst++ = '%';
+-		*dst++ = *src++;
++			*dst++ = '%';
++		} else if (c < 0x20 || c == 0x7f) {
++			*dst++ = '?';
++		} else {
++			*dst++ = c;
++		}
+ 	}
+ 	*dst = '\0';
+ 
+diff --git a/test/test-utils.c b/test/test-utils.c
+index e80754be..1c17bdb0 100644
+--- a/test/test-utils.c
++++ b/test/test-utils.c
+@@ -1281,6 +1281,16 @@ START_TEST(strsanitize_test)
+ 		{ "x %", "x %%" },
+ 		{ "%sx", "%%sx" },
+ 		{ "%s%s", "%%s%%s" },
++		{ "\t", "?" },
++		{ "\n", "?" },
++		{ "\r", "?" },
++		{ "\x1b[31m", "?[31m" },
++		{ "foo\tbar", "foo?bar" },
++		{ "foo\nbar", "foo?bar" },
++		{ "\x01\x1f\x7f", "???" },
++		{ "clean", "clean" },
++		{ "a\x1b[0mb", "a?[0mb" },
++		{ "%\n", "%%?" },
+ 		{ NULL, NULL },
+ 	};
+ 

--- a/meta-core/recipes-graphics/wayland/libinput/CVE-2026-50292-02.patch
+++ b/meta-core/recipes-graphics/wayland/libinput/CVE-2026-50292-02.patch
@@ -1,0 +1,94 @@
+From df7f975f1dd8e5a5c23acb22872b7c6a7218b7ec Mon Sep 17 00:00:00 2001
+From: Peter Hutterer <peter.hutterer@who-t.net>
+Date: Mon, 1 Jun 2026 10:48:24 +1000
+Subject: [PATCH] libinput-device-group: sanitize phys before printing it
+
+A malicious uinput device could set the phys value (via UI_SET_PHYS)
+to contain a '\n'. When the value is printed as part of the device group
+the udev rules will interpret it as separate property.
+
+Depending on the property this can cause local privilege escalation.
+
+Closes #1296
+
+Found-by: Csome
+(cherry picked from commit 76f0d8a7f57e2868882864b4611281f12f704b55)
+
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1489>
+
+CVE: CVE-2026-50292
+Upstream-Status: Backport [https://gitlab.freedesktop.org/libinput/libinput/-/commit/b2bde9504d42a5976d76e1f27c640dc561fbd99b]
+[resolved conflicts based on debian 1.22.1-1+deb12u1 patch]
+Signed-off-by: Andrej Koehler <andrej.koehler@gmx.net>
+---
+ udev/libinput-device-group.c | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/udev/libinput-device-group.c b/udev/libinput-device-group.c
+index 0622ba33..f434a3fb 100644
+--- a/udev/libinput-device-group.c
++++ b/udev/libinput-device-group.c
+@@ -110,7 +110,8 @@ wacom_handle_ekr(struct udev_device *device,
+ 
+ 	udev_list_entry_foreach(entry, udev_enumerate_get_list_entry(e)) {
+ 		struct udev_device *d;
+-		const char *path, *phys;
++		char *phys = NULL;
++		const char *path;
+ 		const char *pidstr, *vidstr;
+ 		int pid, vid, dist;
+ 
+@@ -125,7 +126,7 @@ wacom_handle_ekr(struct udev_device *device,
+ 
+ 		vidstr = udev_device_get_property_value(d, "ID_VENDOR_ID");
+ 		pidstr = udev_device_get_property_value(d, "ID_MODEL_ID");
+-		phys = udev_device_get_sysattr_value(d, "phys");
++		phys = str_sanitize(udev_device_get_sysattr_value(d, "phys"));
+ 
+ 		if (vidstr && pidstr && phys &&
+ 		    safe_atoi_base(vidstr, &vid, 16) &&
+@@ -139,11 +140,13 @@ wacom_handle_ekr(struct udev_device *device,
+ 				best_dist = dist;
+ 
+ 				free(*phys_attr);
+-				*phys_attr = safe_strdup(phys);
++				*phys_attr = phys;
++				phys = NULL;
+ 			}
+ 		}
+ 
+ 		udev_device_unref(d);
++		free(phys);
+ 	}
+ 
+ 	udev_enumerate_unref(e);
+@@ -154,8 +157,8 @@ int main(int argc, char **argv)
+ 	int rc = 1;
+ 	struct udev *udev = NULL;
+ 	struct udev_device *device = NULL;
+-	const char *syspath,
+-	           *phys = NULL;
++	char *phys = NULL;
++	const char *syspath = NULL;
+ 	const char *product;
+ 	int bustype, vendor_id, product_id, version;
+ 	char group[1024];
+@@ -179,8 +182,7 @@ int main(int argc, char **argv)
+ 	 * bit and use the remainder as device group identifier */
+ 	while (device != NULL) {
+ 		struct udev_device *parent;
+-
+-		phys = udev_device_get_sysattr_value(device, "phys");
++		phys = str_sanitize(udev_device_get_sysattr_value(device, "phys"));
+ 		if (phys)
+ 			break;
+ 
+@@ -249,6 +251,8 @@ int main(int argc, char **argv)
+ 
+ 	printf("LIBINPUT_DEVICE_GROUP=%s\n", group);
+ 
++	free(phys);
++
+ 	rc = 0;
+ out:
+ 	if (device)

--- a/meta-core/recipes-graphics/wayland/libinput_1.19.4.bbappend
+++ b/meta-core/recipes-graphics/wayland/libinput_1.19.4.bbappend
@@ -1,3 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "\
+    file://CVE-2026-50292-01.patch \
+    file://CVE-2026-50292-02.patch \
+    "
+
 # cpe-incorrect:
 # The lua plugin was not even added until 1.29.901~96, therefore this CVE does
 # not apply to our version and we can safely ignore it.

--- a/meta-core/recipes-graphics/wayland/libinput_1.19.4.bbappend
+++ b/meta-core/recipes-graphics/wayland/libinput_1.19.4.bbappend
@@ -1,0 +1,4 @@
+# cpe-incorrect:
+# The lua plugin was not even added until 1.29.901~96, therefore this CVE does
+# not apply to our version and we can safely ignore it.
+CVE_CHECK_IGNORE += "CVE-2026-35093 CVE-2026-35094"


### PR DESCRIPTION
ignore CVE-2026-35093, CVE-2026-35094

Backports the fix for CVE-2026-50292 from upstream
Resolved conflicts based on debian 1.22.1-1+deb12u1 patch.