### PR TITLE
core: openssh: fix patch-fuzz QA Issue (kirkstone)

### DIFF
--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2025-61984-tests.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2025-61984-tests.patch
@@ -1,4 +1,4 @@
-From 2d4014d58741293dd534d51e77a8ab8014baf8b0 Mon Sep 17 00:00:00 2001
+From b7e38270817454008fe0a9d42973784bdb2ab14b Mon Sep 17 00:00:00 2001
 From: "djm@openbsd.org" <djm@openbsd.org>
 Date: Thu, 4 Sep 2025 03:04:44 +0000
 Subject: [PATCH] Add more username validity checks
@@ -18,6 +18,7 @@ Patch-Name: CVE-2025-61984-tests.patch
 CVE: CVE-2025-61984
 Upstream-Status: Backport [https://salsa.debian.org/ssh-team/openssh/-/commit/c951523d46d4a953799858a10fd8204247d137ea]
 Signed-off-by: Andrej Koehler <andrej.koehler@gmx.net>
+
 ---
  regress/percent.sh | 37 +++++++++++++++++++++++++++++++++++--
  1 file changed, 35 insertions(+), 2 deletions(-)

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2025-61984.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2025-61984.patch
@@ -1,4 +1,4 @@
-From 31027ba3815f41cb77db1a49a55cdc0eba6ba1a3 Mon Sep 17 00:00:00 2001
+From 159a8a68a51c9d1bca5bb1658b969005cfcb2a25 Mon Sep 17 00:00:00 2001
 From: "djm@openbsd.org" <djm@openbsd.org>
 Date: Thu, 4 Sep 2025 00:29:09 +0000
 Subject: [PATCH] Refuse usernames that include control characters
@@ -36,12 +36,13 @@ variable declarations and initialization, but the actual code that uses it is mi
 CVE: CVE-2025-61984
 Upstream-Status: Backport [https://salsa.debian.org/ssh-team/openssh/-/commit/0a03d5cbc258c2ef5e7a117d6ba844daa599193a]
 Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+
 ---
  ssh.c | 19 ++++++++++++++++---
  1 file changed, 16 insertions(+), 3 deletions(-)
 
 diff --git a/ssh.c b/ssh.c
-index 82ed15f8f..72a5b16f7 100644
+index 82ed15f..72a5b16 100644
 --- a/ssh.c
 +++ b/ssh.c
 @@ -634,6 +634,8 @@ valid_ruser(const char *s)

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35385.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35385.patch
@@ -1,4 +1,4 @@
-From 494c1b7c8c29b9822506d4910d760d6e03947be7 Mon Sep 17 00:00:00 2001
+From e0e77197d1d563fd20d89cb40a9f85aea4a13627 Mon Sep 17 00:00:00 2001
 From: "djm@openbsd.org" <djm@openbsd.org>
 Date: Thu, 2 Apr 2026 07:42:16 +0000
 Subject: [PATCH] upstream: when downloading files as root in legacy (-O) mode
@@ -16,12 +16,13 @@ OpenBSD-Commit-ID: 49e902fca8dd933a92a9b547ab31f63e86729fa1
 CVE: CVE-2026-35385
 Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/487e8ac146f7d6616f65c125d5edb210519b833a]
 Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+
 ---
  scp.c | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/scp.c b/scp.c
-index 519bffa1b..2e37da4a3 100644
+index 519bffa..2e37da4 100644
 --- a/scp.c
 +++ b/scp.c
 @@ -1606,8 +1606,10 @@ sink(int argc, char **argv, const char *src)

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-01.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-01.patch
@@ -1,4 +1,4 @@
-From 03f48bf94b98fd9454cd8d8e1b4febb57c082a4a Mon Sep 17 00:00:00 2001
+From 400236bd41b94d19daca50f6cc3d1235535a0cf7 Mon Sep 17 00:00:00 2001
 From: "djm@openbsd.org" <djm@openbsd.org>
 Date: Mon, 30 Mar 2026 07:18:24 +0000
 Subject: [PATCH] upstream: apply the same validity rules to usernames and
@@ -32,6 +32,7 @@ OpenBSD-Commit-ID: f05ad8a1eb5f6735f9a935a71a90580226759263
 CVE: CVE-2026-35386
 Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/0a0ef4515361143cad21afa072319823854c1cf6]
 Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+
 ---
  readconf.c | 122 +++++++++++++++++++++++++++++++++++++----------------
  readconf.h |   4 +-
@@ -39,7 +40,7 @@ Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
  3 files changed, 94 insertions(+), 80 deletions(-)
 
 diff --git a/readconf.c b/readconf.c
-index f26fabaa6..438b84ce6 100644
+index f26faba..438b84c 100644
 --- a/readconf.c
 +++ b/readconf.c
 @@ -1328,9 +1328,6 @@ parse_char_array:
@@ -212,7 +213,7 @@ index f26fabaa6..438b84ce6 100644
  	free(host);
  	return ret;
 diff --git a/readconf.h b/readconf.h
-index ded13c943..568db471c 100644
+index ded13c9..568db47 100644
 --- a/readconf.h
 +++ b/readconf.h
 @@ -229,7 +229,9 @@ int	 process_config_line(Options *, struct passwd *, const char *,
@@ -227,7 +228,7 @@ index ded13c943..568db471c 100644
  int	 default_ssh_port(void);
  int	 option_clear_or_none(const char *);
 diff --git a/ssh.c b/ssh.c
-index 72a5b16f7..7d6fa9259 100644
+index 72a5b16..7d6fa92 100644
 --- a/ssh.c
 +++ b/ssh.c
 @@ -611,43 +611,6 @@ ssh_conn_info_free(struct ssh_conn_info *cinfo)

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-02.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-02.patch
@@ -1,7 +1,11 @@
-From 1df09b3e69a9505f245c31651ac009d2a5bac323 Mon Sep 17 00:00:00 2001
+From aa98fc731a16d7bf6e15308c3d9cf28f5133ee1f Mon Sep 17 00:00:00 2001
 From: "djm@openbsd.org" <djm@openbsd.org>
 Date: Thu, 2 Apr 2026 07:50:55 +0000
 Subject: [PATCH] upstream: move username validity check for usernames
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
  specified on
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -27,12 +31,13 @@ OpenBSD-Commit-ID: 25ef72223f5ccf1c38d307ae77c23c03f59acc55
 CVE: CVE-2026-35386
 Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/76685c9b09a66435cd2ad8373246adf1c53976d3]
 Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+
 ---
  ssh.c | 6 ++++++
  1 file changed, 6 insertions(+)
 
 diff --git a/ssh.c b/ssh.c
-index 7d6fa9259..35b694f33 100644
+index 7d6fa92..35b694f 100644
 --- a/ssh.c
 +++ b/ssh.c
 @@ -1102,6 +1102,12 @@ main(int ac, char **av)
@@ -47,5 +52,4 @@ index 7d6fa9259..35b694f33 100644
 +		fatal("remote username contains invalid characters");
  	if (!ssh_valid_hostname(host))
  		fatal("hostname contains invalid characters");
-
  	host_arg = xstrdup(host);

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-03.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35386-03.patch
@@ -1,4 +1,4 @@
-From c14af889a8861da208c05ff9fe5d39b75dd3c2a0 Mon Sep 17 00:00:00 2001
+From 9f70a0be669112cc1ec252eeb9bc785eaa139bba Mon Sep 17 00:00:00 2001
 From: "djm@openbsd.org" <djm@openbsd.org>
 Date: Thu, 2 Apr 2026 07:52:15 +0000
 Subject: [PATCH] upstream: adapt to username validity check change
@@ -9,12 +9,13 @@ Change-Id: Ieaaf35619abeabf3f771982ab25f6aa81d8e4a11
 CVE: CVE-2026-35386
 Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/5aa09926fbf050d484a79717fadec8360c5c5645]
 Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+
 ---
  regress/percent.sh | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/regress/percent.sh b/regress/percent.sh
-index fd48156fe..699fa7124 100644
+index fd48156..699fa71 100644
 --- a/regress/percent.sh
 +++ b/regress/percent.sh
 @@ -150,4 +150,4 @@ ${SSH} -F $OBJ/ssh_proxy -G "${FOO}@somehost" && fail "user-at expanded env"

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35387.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35387.patch
@@ -1,4 +1,4 @@
-From bea09f5eeef5e8daf6d733ede649628282ca276e Mon Sep 17 00:00:00 2001
+From adc38933a9f0792b70e11c0ebacf436121633bd8 Mon Sep 17 00:00:00 2001
 From: "djm@openbsd.org" <djm@openbsd.org>
 Date: Thu, 2 Apr 2026 07:48:13 +0000
 Subject: [PATCH] upstream: correctly match ECDSA signature algorithms against
@@ -26,6 +26,7 @@ Patch-Name: CVE-2026-35387.patch
 CVE: CVE-2026-35387
 Upstream-Status: Backport [https://salsa.debian.org/ssh-team/openssh/-/commit/42a8064f37b82f65d3124eddafd078850132354a]
 Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
+
 ---
  auth2-hostbased.c |  7 ++++---
  auth2-pubkey.c    |  7 ++++---
@@ -33,7 +34,7 @@ Signed-off-by: Andrej Koehler <Andrej.Koehler@garmin.com>
  3 files changed, 25 insertions(+), 15 deletions(-)
 
 diff --git a/auth2-hostbased.c b/auth2-hostbased.c
-index 36b9d2f5b..6882a4f0f 100644
+index 36b9d2f..6882a4f 100644
 --- a/auth2-hostbased.c
 +++ b/auth2-hostbased.c
 @@ -96,9 +96,10 @@ userauth_hostbased(struct ssh *ssh, const char *method)
@@ -51,7 +52,7 @@ index 36b9d2f5b..6882a4f0f 100644
  	}
  	if (sshkey_type_plain(key->type) == KEY_RSA &&
 diff --git a/auth2-pubkey.c b/auth2-pubkey.c
-index 9c2298fc8..fbab6bd3a 100644
+index 9c2298f..fbab6bd 100644
 --- a/auth2-pubkey.c
 +++ b/auth2-pubkey.c
 @@ -150,9 +150,10 @@ userauth_pubkey(struct ssh *ssh, const char *method)
@@ -69,7 +70,7 @@ index 9c2298fc8..fbab6bd3a 100644
  	}
  	if (sshkey_type_plain(key->type) == KEY_RSA &&
 diff --git a/sshconnect2.c b/sshconnect2.c
-index 6cfae2af0..491ec5fce 100644
+index 6cfae2a..491ec5f 100644
 --- a/sshconnect2.c
 +++ b/sshconnect2.c
 @@ -92,10 +92,15 @@ extern Options options;


### PR DESCRIPTION
Hello,

This was tested in the same build as https://github.com/garmin/meta-lts-collab/pull/147. The warning is no longer there, and devtool didn't modify the actual code hunks in the patches (as you can see in the diff).

Best regards,

