### PR TITLE
core: util-linux: Backport fix for CVE-2026-27456

### DIFF
--- a/meta-core/recipes-core/util-linux/util-linux/CVE-2026-27456.patch
+++ b/meta-core/recipes-core/util-linux/util-linux/CVE-2026-27456.patch
@@ -1,0 +1,129 @@
+From 6529d0cd24f89e1f539ce25bbc3f871dcfb56cb8 Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Thu, 19 Feb 2026 13:59:46 +0100
+Subject: [PATCH] loopdev: add LOOPDEV_FL_NOFOLLOW to prevent symlink attacks
+
+Add a new LOOPDEV_FL_NOFOLLOW flag for loop device context that
+prevents symlink following in both path canonicalization and file open.
+
+When set:
+- loopcxt_set_backing_file() uses strdup() instead of
+  ul_canonicalize_path() (which calls realpath() and follows symlinks)
+- loopcxt_setup_device() adds O_NOFOLLOW to open() flags
+
+The flag is set for non-root (restricted) mount operations in
+libmount's loop device hook. This prevents a TOCTOU race condition
+where an attacker could replace the backing file (specified in
+/etc/fstab) with a symlink to an arbitrary root-owned file between
+path resolution and open().
+
+Vulnerable Code Flow:
+
+  mount /mnt/point (non-root, SUID)
+    mount.c: sanitize_paths() on user args (mountpoint only)
+    mnt_context_mount()
+      mnt_context_prepare_mount()
+        mnt_context_apply_fstab()           <-- source path from fstab
+        hooks run at MNT_STAGE_PREP_SOURCE
+          hook_loopdev.c: setup_loopdev()
+            backing_file = fstab source path ("/home/user/disk.img")
+            loopcxt_set_backing_file()       <-- calls realpath() as ROOT
+              ul_canonicalize_path()         <-- follows symlinks!
+            loopcxt_setup_device()
+              open(lc->filename, O_RDWR|O_CLOEXEC)  <-- no O_NOFOLLOW
+
+Two vulnerabilities in the path:
+
+1) loopcxt_set_backing_file() calls ul_canonicalize_path() which uses
+   realpath() -- this follows symlinks as euid=0. If the attacker swaps
+   the file to a symlink before this call, lc->filename becomes the
+   resolved target path (e.g., /root/secret.img).
+
+2) loopcxt_setup_device() opens lc->filename without O_NOFOLLOW. Even
+   if canonicalization happened correctly, the file can be swapped to a
+   symlink between canonicalize and open.
+
+Addresses: https://github.com/util-linux/util-linux/security/advisories/GHSA-qq4x-vfq4-9h9g
+Signed-off-by: Karel Zak <kzak@redhat.com>
+
+[Minor modifications required to match the functional change of the
+original patch]
+
+CVE: CVE-2026-27456
+Upstream-Status: Backport [https://github.com/util-linux/util-linux/commit/5e390467b26a3cf3fecc04e1a0d482dff3162fc4]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ include/loopdev.h              |  3 ++-
+ lib/loopdev.c                  | 13 ++++++++++---
+ libmount/src/context_loopdev.c |  3 ++-
+ 3 files changed, 14 insertions(+), 5 deletions(-)
+
+diff --git a/include/loopdev.h b/include/loopdev.h
+index 0e3a7517a..2700ee80c 100644
+--- a/include/loopdev.h
++++ b/include/loopdev.h
+@@ -122,7 +122,8 @@ enum {
+ 	LOOPDEV_FL_NOIOCTL	= (1 << 6),
+ 	LOOPDEV_FL_DEVSUBDIR	= (1 << 7),
+ 	LOOPDEV_FL_CONTROL	= (1 << 8),	/* system with /dev/loop-control */
+-	LOOPDEV_FL_SIZELIMIT	= (1 << 9)
++	LOOPDEV_FL_SIZELIMIT	= (1 << 9),
++	LOOPDEV_FL_NOFOLLOW	= (1 << 10)	/* O_NOFOLLOW, don't follow symlinks */
+ };
+ 
+ /*
+diff --git a/lib/loopdev.c b/lib/loopdev.c
+index 99a093926..835e5a002 100644
+--- a/lib/loopdev.c
++++ b/lib/loopdev.c
+@@ -1153,7 +1153,10 @@ int loopcxt_set_backing_file(struct loopdev_cxt *lc, const char *filename)
+ 	if (!lc)
+ 		return -EINVAL;
+ 
+-	lc->filename = canonicalize_path(filename);
++	if (lc->flags & LOOPDEV_FL_NOFOLLOW)
++		lc->filename = strdup(filename);
++	else
++		lc->filename = canonicalize_path(filename);
+ 	if (!lc->filename)
+ 		return -errno;
+ 
+@@ -1273,7 +1276,8 @@ static int loopcxt_check_size(struct loopdev_cxt *lc, int file_fd)
+  */
+ int loopcxt_setup_device(struct loopdev_cxt *lc)
+ {
+-	int file_fd, dev_fd, mode = O_RDWR, rc = -1, cnt = 0, err, again;
++	int file_fd, dev_fd, rc = -1, cnt = 0, err, again;
++	mode_t flags = O_CLOEXEC, mode = O_RDWR;
+ 	int errsv = 0;
+ 
+ 	if (!lc || !*lc->device || !lc->filename)
+@@ -1287,7 +1291,10 @@ int loopcxt_setup_device(struct loopdev_cxt *lc)
+ 	if (lc->info.lo_flags & LO_FLAGS_READ_ONLY)
+ 		mode = O_RDONLY;
+ 
+-	if ((file_fd = open(lc->filename, mode | O_CLOEXEC)) < 0) {
++	if (lc->flags & LOOPDEV_FL_NOFOLLOW)
++		flags |= O_NOFOLLOW;
++
++	if ((file_fd = open(lc->filename, mode | flags)) < 0) {
+ 		if (mode != O_RDONLY && (errno == EROFS || errno == EACCES))
+ 			file_fd = open(lc->filename, mode = O_RDONLY);
+ 
+diff --git a/libmount/src/context_loopdev.c b/libmount/src/context_loopdev.c
+index c5fc80d77..b2660c72e 100644
+--- a/libmount/src/context_loopdev.c
++++ b/libmount/src/context_loopdev.c
+@@ -289,7 +289,8 @@ int mnt_context_setup_loopdev(struct libmnt_context *cxt)
+ 	}
+ 
+ 	DBG(LOOP, ul_debugobj(cxt, "not found; create a new loop device"));
+-	rc = loopcxt_init(&lc, 0);
++	rc = loopcxt_init(&lc,
++			mnt_context_is_restricted(cxt) ? LOOPDEV_FL_NOFOLLOW : 0);
+ 	if (rc)
+ 		goto done_no_deinit;
+ 	if (loopval) {
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/util-linux/util-linux_2.35.1.bbappend
+++ b/meta-core/recipes-core/util-linux/util-linux_2.35.1.bbappend
@@ -6,4 +6,5 @@ SRC_URI_append = " \
     file://CVE-2024-28085-0003.patch \
     file://CVE-2024-28085-0004.patch \
     file://CVE-2024-28085-0005.patch \
+    file://CVE-2026-27456.patch \
 "


### PR DESCRIPTION
Backports the fix for CVE-2026-27456 from
https://github.com/util-linux/util-linux/commit/5e390467b26a3cf3fecc04e1a0d482dff3162fc4