### PR TITLE
ci: Disable broken ptests

### DIFF
--- a/classes/skip-ptests-problems.bbclass
+++ b/classes/skip-ptests-problems.bbclass
@@ -1,0 +1,7 @@
+PTESTS_PROBLEMS ??= ""
+
+python () {
+    ptest_problems = set(d.getVar("PTESTS_PROBLEMS").split())
+    if "{}-ptest".format(d.getVar("BPN")) in ptest_problems:
+        d.setVar("PTEST_ENABLED", "0")
+}

--- a/conf/ci.conf
+++ b/conf/ci.conf
@@ -13,6 +13,9 @@ IMAGE_CLASSES += "testimage"
 TEST_TARGET = "qemu"
 TEST_SUITES = "ping ssh ptest"
 
+# Disable ptests for every package in PTESTS_PROBLEMS
+INHERIT += "skip-ptests-problems"
+
 # do_testimage configuration
 TEST_RUNQEMUPARAMS += "kvm nographic slirp snapshot"
 TEST_QEMUPARAMS += "-smp 8"

--- a/scripts/get-bitbake-targets.py
+++ b/scripts/get-bitbake-targets.py
@@ -75,7 +75,7 @@ def get_all_bpns() -> List[str]:
         List[str]: List of all BPNs found in the layer.
     """
     layer_dir = Path(__file__).resolve().parent.parent
-    return sorted(list(map(get_bpn, layer_dir.rglob("*.bb*"))))
+    return sorted(list(map(get_bpn, filter(lambda x: x.suffix in (".bb", ".bbappend"), layer_dir.rglob("*.bb*")))))
 
 
 def get_bpns(


### PR DESCRIPTION
Adds anonymous function to ci.conf that disables ptests for any package that is listed in the upstream PTESTS_PROBLEMS variable. If any other packages are determined to be problematic, they can be appended to this variable as well.

Fixes #156 