### PR TITLE
core: openssh: backport fix for CVE-2026-60002 (kirkstone)

### DIFF
--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-60002.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-60002.patch
@@ -1,0 +1,235 @@
+From 34be748bbeb2504c9f08a567c106d800ee35299a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jo=C3=A3o=20Marcos=20Costa?= <joaomarcos.costa@bootlin.com>
+Date: Fri, 24 Jul 2026 09:38:22 +0000
+Subject: [PATCH] upstream: fix ownership and lifetime of several bits of
+ client
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CVE: CVE-2026-60002
+
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/e8bdfb151a356d0171fea4194dd205fbb252be23]
+
+state that need to persist for the life of the connection, especially the
+cached hostkey that was being incorrectly freed early on some paths, possibly
+allowing its use after free.
+
+Reported by Zhenpeng (Leo) Lin from depthfirst.com
+
+OpenBSD-Commit-ID: faaa6ad72e7d69d41fa8b197b606265b7d9bc73f
+Signed-off-by: João Marcos Costa (Schneider Electric) <joaomarcos.costa@bootlin.com>
+---
+ ssh.c         | 25 +++----------------------
+ sshconnect.c  | 47 ++++++++++++++++++++++++++++++++++++++++++++---
+ sshconnect.h  |  9 ++++++---
+ sshconnect2.c | 16 ++++++++--------
+ 4 files changed, 61 insertions(+), 36 deletions(-)
+
+diff --git a/ssh.c b/ssh.c
+index 35b694f..6e97119 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: ssh.c,v 1.573 2022/02/08 08:59:12 dtucker Exp $ */
++/* $OpenBSD: ssh.c,v 1.634 2026/07/06 07:49:58 djm Exp $ */
+ /*
+  * Author: Tatu Ylonen <ylo@cs.hut.fi>
+  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+@@ -592,25 +592,6 @@ set_addrinfo_port(struct addrinfo *addrs, int port)
+ 	}
+ }
+ 
+-static void
+-ssh_conn_info_free(struct ssh_conn_info *cinfo)
+-{
+-	if (cinfo == NULL)
+-		return;
+-	free(cinfo->conn_hash_hex);
+-	free(cinfo->shorthost);
+-	free(cinfo->uidstr);
+-	free(cinfo->keyalias);
+-	free(cinfo->thishost);
+-	free(cinfo->host_arg);
+-	free(cinfo->portstr);
+-	free(cinfo->remhost);
+-	free(cinfo->remuser);
+-	free(cinfo->homedir);
+-	free(cinfo->locuser);
+-	free(cinfo);
+-}
+-
+ /*
+  * Main program for the ssh client.
+  */
+@@ -1678,8 +1659,8 @@ main(int ac, char **av)
+ 	ssh_signal(SIGCHLD, main_sigchld_handler);
+ 
+ 	/* Log into the remote system.  Never returns if the login fails. */
+-	ssh_login(ssh, &sensitive_data, host, (struct sockaddr *)&hostaddr,
+-	    options.port, pw, timeout_ms, cinfo);
++	ssh_login(ssh, &sensitive_data, host, &hostaddr, options.port,
++	pw, timeout_ms, cinfo);
+ 
+ 	/* We no longer need the private host keys.  Clear them now. */
+ 	if (sensitive_data.nkeys != 0) {
+diff --git a/sshconnect.c b/sshconnect.c
+index ebecc83..f820892 100644
+--- a/sshconnect.c
++++ b/sshconnect.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: sshconnect.c,v 1.356 2021/12/19 22:10:24 djm Exp $ */
++/* $OpenBSD: sshconnect.c,v 1.384 2026/07/06 07:49:58 djm Exp $ */
+ /*
+  * Author: Tatu Ylonen <ylo@cs.hut.fi>
+  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+@@ -84,6 +84,47 @@ extern char *__progname;
+ static int show_other_keys(struct hostkeys *, struct sshkey *);
+ static void warn_changed_key(struct sshkey *);
+ 
++void
++ssh_conn_info_free(struct ssh_conn_info *cinfo)
++{
++   if (cinfo == NULL)
++       return;
++   free(cinfo->conn_hash_hex);
++   free(cinfo->shorthost);
++   free(cinfo->uidstr);
++   free(cinfo->keyalias);
++   free(cinfo->thishost);
++   free(cinfo->host_arg);
++   free(cinfo->portstr);
++   free(cinfo->remhost);
++   free(cinfo->remuser);
++   free(cinfo->homedir);
++   free(cinfo->locuser);
++   freezero(cinfo, sizeof(*cinfo));
++}
++
++struct ssh_conn_info *
++ssh_conn_info_dup(const struct ssh_conn_info *cinfo)
++{
++   struct ssh_conn_info *ret;
++
++   if (cinfo == NULL)
++       return NULL;
++   ret = xcalloc(1, sizeof(*ret));
++   ret->conn_hash_hex = xstrdup(cinfo->conn_hash_hex);
++   ret->shorthost = xstrdup(cinfo->shorthost);
++   ret->uidstr = xstrdup(cinfo->uidstr);
++   ret->keyalias = xstrdup(cinfo->keyalias);
++   ret->thishost = xstrdup(cinfo->thishost);
++   ret->host_arg = xstrdup(cinfo->host_arg);
++   ret->portstr = xstrdup(cinfo->portstr);
++   ret->remhost = xstrdup(cinfo->remhost);
++   ret->remuser = xstrdup(cinfo->remuser);
++   ret->homedir = xstrdup(cinfo->homedir);
++   ret->locuser = xstrdup(cinfo->locuser);
++   return ret;
++}
++
+ /* Expand a proxy command */
+ static char *
+ expand_proxy_command(const char *proxy_command, const char *user,
+@@ -1538,8 +1579,8 @@ out:
+  */
+ void
+ ssh_login(struct ssh *ssh, Sensitive *sensitive, const char *orighost,
+-    struct sockaddr *hostaddr, u_short port, struct passwd *pw, int timeout_ms,
+-    const struct ssh_conn_info *cinfo)
++    struct sockaddr_storage *hostaddr, u_short port, struct passwd *pw,
++    int timeout_ms, const struct ssh_conn_info *cinfo)
+ {
+ 	char *host;
+ 	char *server_user, *local_user;
+diff --git a/sshconnect.h b/sshconnect.h
+index f518a9a..67ceee9 100644
+--- a/sshconnect.h
++++ b/sshconnect.h
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: sshconnect.h,v 1.46 2020/12/22 00:15:23 djm Exp $ */
++/* $OpenBSD: sshconnect.h,v 1.51 2026/07/06 07:49:58 djm Exp $ */
+ 
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+@@ -69,7 +69,7 @@ int	 ssh_connect(struct ssh *, const char *, const char *,
+ void	 ssh_kill_proxy_command(void);
+ 
+ void	 ssh_login(struct ssh *, Sensitive *, const char *,
+-    struct sockaddr *, u_short, struct passwd *, int,
++    struct sockaddr_storage *, u_short, struct passwd *, int,
+     const struct ssh_conn_info *);
+ 
+ int	 verify_host_key(char *, struct sockaddr *, struct sshkey *,
+@@ -78,7 +78,7 @@ int	 verify_host_key(char *, struct sockaddr *, struct sshkey *,
+ void	 get_hostfile_hostname_ipaddr(char *, struct sockaddr *, u_short,
+     char **, char **);
+ 
+-void	 ssh_kex2(struct ssh *ssh, char *, struct sockaddr *, u_short,
++void	 ssh_kex2(struct ssh *ssh, char *, struct sockaddr_storage *, u_short,
+     const struct ssh_conn_info *);
+ 
+ void	 ssh_userauth2(struct ssh *ssh, const char *, const char *,
+@@ -92,3 +92,6 @@ void	 maybe_add_key_to_agent(const char *, struct sshkey *,
+ void	 load_hostkeys_command(struct hostkeys *, const char *,
+     const char *, const struct ssh_conn_info *,
+     const struct sshkey *, const char *);
++
++void ssh_conn_info_free(struct ssh_conn_info *);
++struct ssh_conn_info *ssh_conn_info_dup(const struct ssh_conn_info *);
+diff --git a/sshconnect2.c b/sshconnect2.c
+index 491ec5f..a446cd9 100644
+--- a/sshconnect2.c
++++ b/sshconnect2.c
+@@ -90,7 +90,7 @@ extern Options options;
+  */
+ 
+ static char *xxx_host;
+-static struct sockaddr *xxx_hostaddr;
++static struct sockaddr_storage xxx_hostaddr;
+ static const struct ssh_conn_info *xxx_conn_info;
+ static int key_type_allowed(struct sshkey *, const char *);
+ 
+@@ -101,7 +101,7 @@ verify_host_key_callback(struct sshkey *hostkey, struct ssh *ssh)
+ 		fatal("Server host key %s not in HostKeyAlgorithms",
+ 		    sshkey_ssh_name(hostkey));
+ 	}
+-	if (verify_host_key(xxx_host, xxx_hostaddr, hostkey,
++	if (verify_host_key(xxx_host, (struct sockaddr *)&xxx_hostaddr, hostkey,
+ 	    xxx_conn_info) != 0)
+ 		fatal("Host key verification failed.");
+ 	return 0;
+@@ -218,16 +218,16 @@ order_hostkeyalgs(char *host, struct sockaddr *hostaddr, u_short port,
+ }
+ 
+ void
+-ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port,
+-    const struct ssh_conn_info *cinfo)
++ssh_kex2(struct ssh *ssh, char *host, struct sockaddr_storage *hostaddr,
++    u_short port, const struct ssh_conn_info *cinfo)
+ {
+ 	char *myproposal[PROPOSAL_MAX] = { KEX_CLIENT };
+ 	char *s, *all_key;
+ 	int r, use_known_hosts_order = 0;
+ 
+-	xxx_host = host;
+-	xxx_hostaddr = hostaddr;
+-	xxx_conn_info = cinfo;
++	xxx_host = xstrdup(host);
++	xxx_hostaddr = *hostaddr;
++	xxx_conn_info = ssh_conn_info_dup(cinfo);
+ 
+ 	/*
+ 	 * If the user has not specified HostkeyAlgorithms, or has only
+@@ -263,7 +263,7 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port,
+ 		/* Query known_hosts and prefer algorithms that appear there */
+ 		myproposal[PROPOSAL_SERVER_HOST_KEY_ALGS] =
+ 		    compat_pkalg_proposal(ssh,
+-		    order_hostkeyalgs(host, hostaddr, port, cinfo));
++		    order_hostkeyalgs(host, (struct sockaddr *)&hostaddr, port, cinfo));
+ 	} else {
+ 		/* Use specified HostkeyAlgorithms exactly */
+ 		myproposal[PROPOSAL_SERVER_HOST_KEY_ALGS] =
+-- 
+2.39.5
+

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -7,4 +7,5 @@ SRC_URI:append = " \
     file://CVE-2026-35386-01.patch \
     file://CVE-2026-35386-02.patch \
     file://CVE-2026-35386-03.patch \
+    file://CVE-2026-60002.patch \
     "


### PR DESCRIPTION
Hello,

I'm also adding a minor fix to the build instructions. For more details on the CVE itself: https://nvd.nist.gov/vuln/detail/CVE-2026-60002

Best regards,