### PR TITLE
core: glibc: backport fix for CVE-2026-5435

### DIFF
--- a/meta-core/recipes-core/glibc/glibc/CVE-2026-5435.patch
+++ b/meta-core/recipes-core/glibc/glibc/CVE-2026-5435.patch
@@ -1,0 +1,132 @@
+From 3c144f41b60d0b7af252a482be3285c68f944f82 Mon Sep 17 00:00:00 2001
+From: Benjamin Robin <benjamin.robin@bootlin.com>
+Date: Thu, 2 Jul 2026 09:35:41 +0200
+Subject: [PATCH] resolv: More types as unknown in ns_sprintrrf (CVE-2026-5435)
+
+Specifically, CERT, TKEY, TSIG, OPT.  This removes the buggy
+implementations of TSIG, fixing bug 34033, and partially
+fixing bug 34069.
+
+CVE: CVE-2026-5435
+Upstream-Status: Backport [https://sourceware.org/git/?p=glibc.git;a=commit;h=ca44a6609c29a683b03575fa035c6d17aa591e72]
+
+Signed-off-by: Benjamin Robin <benjamin.robin@bootlin.com>
+---
+ resolv/ns_print.c | 95 -----------------------------------------------
+ 1 file changed, 95 deletions(-)
+
+diff --git a/resolv/ns_print.c b/resolv/ns_print.c
+index 43f39edf61c8..3cf2f6a370bc 100644
+--- a/resolv/ns_print.c
++++ b/resolv/ns_print.c
+@@ -434,96 +434,6 @@ ns_sprintrrf(const u_char *msg, size_t msglen,
+		break;
+	    }
+
+-	case ns_t_cert: {
+-		u_int c_type, key_tag, alg;
+-		int n;
+-		unsigned int siz;
+-		char base64_cert[8192], tmp[40];
+-		const char *leader;
+-
+-		c_type  = ns_get16(rdata); rdata += NS_INT16SZ;
+-		key_tag = ns_get16(rdata); rdata += NS_INT16SZ;
+-		alg = (u_int) *rdata++;
+-
+-		len = SPRINTF((tmp, "%d %d %d ", c_type, key_tag, alg));
+-		T(addstr(tmp, len, &buf, &buflen));
+-		siz = (edata-rdata)*4/3 + 4; /* "+4" accounts for trailing \0 */
+-		if (siz > sizeof(base64_cert) * 3/4) {
+-			const char *str = "record too long to print";
+-			T(addstr(str, strlen(str), &buf, &buflen));
+-		}
+-		else {
+-			len = b64_ntop(rdata, edata-rdata, base64_cert, siz);
+-
+-			if (len < 0)
+-				goto formerr;
+-			else if (len > 15) {
+-				T(addstr(" (", 2, &buf, &buflen));
+-				leader = "\n\t\t";
+-				spaced = 0;
+-			}
+-			else
+-				leader = " ";
+-
+-			for (n = 0; n < len; n += 48) {
+-				T(addstr(leader, strlen(leader),
+-					 &buf, &buflen));
+-				T(addstr(base64_cert + n, MIN(len - n, 48),
+-					 &buf, &buflen));
+-			}
+-			if (len > 15)
+-				T(addstr(" )", 2, &buf, &buflen));
+-		}
+-		break;
+-	    }
+-
+-	case ns_t_tkey: {
+-		/* KJD - need to complete this */
+-		u_long t;
+-		int mode, err, keysize;
+-
+-		/* Algorithm name. */
+-		T(addname(msg, msglen, &rdata, origin, &buf, &buflen));
+-		T(addstr(" ", 1, &buf, &buflen));
+-
+-		/* Inception. */
+-		t = ns_get32(rdata);  rdata += NS_INT32SZ;
+-		len = SPRINTF((tmp, "%lu ", t));
+-		T(addstr(tmp, len, &buf, &buflen));
+-
+-		/* Experation. */
+-		t = ns_get32(rdata);  rdata += NS_INT32SZ;
+-		len = SPRINTF((tmp, "%lu ", t));
+-		T(addstr(tmp, len, &buf, &buflen));
+-
+-		/* Mode , Error, Key Size. */
+-		/* Priority, Weight, Port. */
+-		mode = ns_get16(rdata);  rdata += NS_INT16SZ;
+-		err  = ns_get16(rdata);  rdata += NS_INT16SZ;
+-		keysize  = ns_get16(rdata);  rdata += NS_INT16SZ;
+-		len = SPRINTF((tmp, "%u %u %u ", mode, err, keysize));
+-		T(addstr(tmp, len, &buf, &buflen));
+-
+-		/* XXX need to dump key, print otherdata length & other data */
+-		break;
+-	    }
+-
+-	case ns_t_tsig: {
+-		/* BEW - need to complete this */
+-		int n;
+-
+-		T(len = addname(msg, msglen, &rdata, origin, &buf, &buflen));
+-		T(addstr(" ", 1, &buf, &buflen));
+-		rdata += 8; /*%< time */
+-		n = ns_get16(rdata); rdata += INT16SZ;
+-		rdata += n; /*%< sig */
+-		n = ns_get16(rdata); rdata += INT16SZ; /*%< original id */
+-		sprintf(buf, "%d", ns_get16(rdata));
+-		rdata += INT16SZ;
+-		addlen(strlen(buf), &buf, &buflen);
+-		break;
+-	    }
+-
+	case ns_t_a6: {
+		struct in6_addr a;
+		int pbyte, pbit;
+@@ -557,11 +467,6 @@ ns_sprintrrf(const u_char *msg, size_t msglen,
+		break;
+	    }
+
+-	case ns_t_opt: {
+-		len = SPRINTF((tmp, "%u bytes", class));
+-		T(addstr(tmp, len, &buf, &buflen));
+-		break;
+-	    }
+
+	default:
+		snprintf (errbuf, sizeof (errbuf), "unknown RR type %d", type);
+--
+2.54.0

--- a/meta-core/recipes-core/glibc/glibc_2.35.bbappend
+++ b/meta-core/recipes-core/glibc/glibc_2.35.bbappend
@@ -6,6 +6,7 @@ SRC_URI:append = " \
     file://CVE-2026-4438.patch \
     file://CVE-2026-5450.patch \
     file://CVE-2026-5928.patch \
+    file://CVE-2026-5435.patch \
 "
 
 # glibc https://nvd.nist.gov/vuln/detail/CVE-2026-3904


### PR DESCRIPTION
This CVE is marked as High (CVSS v3.x 7.3).

See https://nvd.nist.gov/vuln/detail/CVE-2026-5435 for more details.

`testimage` results:
```
RESULTS:
RESULTS - ping.PingTest.test_ping: PASSED (0.02s)
RESULTS - ptest.PtestRunnerTest.test_ptestrunner_expectsuccess: PASSED (1433.92s)
RESULTS - ssh.SSHTest.test_ssh: PASSED (1.44s)
RESULTS - ptest.PtestRunnerTest.test_ptestrunner_expectfail: SKIPPED (0.00s)
SUMMARY:
core-image-minimal () - Ran 4 tests in 1435.376s
core-image-minimal - OK - All required tests passed (successes=3, skipped=1, failures=0, errors=0)
