### PR TITLE
core: libinput: Backport fix for CVE-2026-50292

### DIFF
--- a/meta-core/recipes-graphics/wayland/libinput/CVE-2026-50292.patch
+++ b/meta-core/recipes-graphics/wayland/libinput/CVE-2026-50292.patch
@@ -1,0 +1,94 @@
+From 1fefd24faad41604066e5c8e5ca199c90f2967e2 Mon Sep 17 00:00:00 2001
+From: Peter Hutterer <peter.hutterer@who-t.net>
+Date: Mon, 1 Jun 2026 10:48:24 +1000
+Subject: [PATCH] libinput-device-group: sanitize phys before printing it
+
+A malicious uinput device could set the phys value (via UI_SET_PHYS)
+to contain a '\n'. When the value is printed as part of the device group
+the udev rules will interpret it as separate property.
+
+Depending on the property this can cause local privilege escalation.
+
+Closes #1296
+
+Found-by: Csome
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1487>
+
+CVE: CVE-2026-50292
+Upstream-Status: Backport [https://gitlab.freedesktop.org/libinput/libinput/-/commit/76f0d8a7f57e2868882864b4611281f12f704b55]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ udev/libinput-device-group.c | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/udev/libinput-device-group.c b/udev/libinput-device-group.c
+index 65d22ec3..3bcc5582 100644
+--- a/udev/libinput-device-group.c
++++ b/udev/libinput-device-group.c
+@@ -110,7 +110,8 @@ wacom_handle_ekr(struct udev_device *device,
+ 
+ 	udev_list_entry_foreach(entry, udev_enumerate_get_list_entry(e)) {
+ 		struct udev_device *d;
+-		const char *path, *phys;
++		char *phys = NULL;
++		const char *path;
+ 		const char *pidstr, *vidstr;
+ 		int pid, vid, dist;
+ 
+@@ -125,7 +126,7 @@ wacom_handle_ekr(struct udev_device *device,
+ 
+ 		vidstr = udev_device_get_property_value(d, "ID_VENDOR_ID");
+ 		pidstr = udev_device_get_property_value(d, "ID_MODEL_ID");
+-		phys = udev_device_get_sysattr_value(d, "phys");
++		phys = str_sanitize(udev_device_get_sysattr_value(d, "phys"));
+ 
+ 		if (vidstr && pidstr && phys &&
+ 		    safe_atoi_base(vidstr, &vid, 16) &&
+@@ -139,11 +140,13 @@ wacom_handle_ekr(struct udev_device *device,
+ 				best_dist = dist;
+ 
+ 				free(*phys_attr);
+-				*phys_attr = strdup(phys);
++				*phys_attr = phys;
++				phys = NULL;
+ 			}
+ 		}
+ 
+ 		udev_device_unref(d);
++		free(phys);
+ 	}
+ 
+ 	udev_enumerate_unref(e);
+@@ -154,8 +157,8 @@ int main(int argc, char **argv)
+ 	int rc = 1;
+ 	struct udev *udev = NULL;
+ 	struct udev_device *device = NULL;
+-	const char *syspath,
+-	           *phys = NULL;
++	char *phys = NULL;
++	const char *syspath = NULL;
+ 	const char *product;
+ 	int bustype, vendor_id, product_id, version;
+ 	char group[1024];
+@@ -179,8 +182,7 @@ int main(int argc, char **argv)
+ 	 * bit and use the remainder as device group identifier */
+ 	while (device != NULL) {
+ 		struct udev_device *parent;
+-
+-		phys = udev_device_get_sysattr_value(device, "phys");
++		phys = str_sanitize(udev_device_get_sysattr_value(device, "phys"));
+ 		if (phys)
+ 			break;
+ 
+@@ -249,6 +251,8 @@ int main(int argc, char **argv)
+ 
+ 	printf("LIBINPUT_DEVICE_GROUP=%s\n", group);
+ 
++	free(phys);
++
+ 	rc = 0;
+ out:
+ 	if (device)
+-- 
+2.54.0
+

--- a/meta-core/recipes-graphics/wayland/libinput_1.15.2.bbappend
+++ b/meta-core/recipes-graphics/wayland/libinput_1.15.2.bbappend
@@ -1,3 +1,9 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI_append = " \
+    file://CVE-2026-50292.patch \
+    "
+
 # cpe-incorrect:
 # The lua plugin was not even added until 1.29.901~96, therefore this CVE does
 # not apply to our version and we can safely ignore it.


### PR DESCRIPTION
Backports the fix for CVE-2026-50292 from
https://gitlab.freedesktop.org/libinput/libinput/-/commit/76f0d8a7f57e2868882864b4611281f12f704b55

Patch modeled after Debian libinput 1.16.4-3+deb11u1 to resolve conflicts, etc.