### PR TITLE
ci: fix cve-check permissions

### DIFF
--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -11,6 +11,8 @@ jobs:
       matrix:
         branch: [dunfell, kirkstone]
     uses: ./.github/workflows/cve-check.yml
+    permissions:
+      contents: read
     with:
       branch: ${{ matrix.branch }}
       runner: yocto_build_host


### PR DESCRIPTION
Ensures permissions are set for cve-check jobs that run as a part of the cve-report pipeline.

Fixes https://github.com/garmin/meta-lts-collab/security/code-scanning/12