### PR TITLE
ci.conf: Add patch-fuzz to ERROR_QA

### DIFF
--- a/conf/ci.conf
+++ b/conf/ci.conf
@@ -27,3 +27,6 @@ QEMU_USE_SLIRP = "1"
 # Ensure there is enough space to run tests
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE = "1124288"
+
+# Error if patches do not apply cleanly. [patch-fuzz]
+ERROR_QA += "patch-fuzz"


### PR DESCRIPTION
Error out if patches do not apply cleanly. [patch-fuzz]
To avoid issues like https://github.com/garmin/meta-lts-collab/pull/149 in the future.