### PR TITLE
core: libxml2: CVE-2025-8732, CVE-2026-0989, CVE-2026-0990, CVE-2026-0992 (dunfell)

### DIFF
--- a/meta-core/recipes-core/libxml/libxml2/CVE-2025-8732.patch
+++ b/meta-core/recipes-core/libxml/libxml2/CVE-2025-8732.patch
@@ -1,0 +1,157 @@
+From c5bd4fa2ed67a0f48c45119f2b16b81cac45c3b4 Mon Sep 17 00:00:00 2001
+From: Nathan <nathan.shain@echohq.com>
+Date: Wed, 10 Sep 2025 18:11:50 +0300
+Subject: [PATCH] fix: Prevent infinite recursion in xmlCatalogListXMLResolve
+
+Origin: https://gitlab.gnome.org/GNOME/libxml2/-/commit/3425dece47c8db600f8d7328ae2d7ddfaa0d7b2d
+Bug: https://gitlab.gnome.org/GNOME/libxml2/-/issues/958
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2025-8732
+
+CVE: CVE-2025-8732
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/libxml2/-/commit/3425dece47c8db600f8d7328ae2d7ddfaa0d7b2d]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ catalog.c                      | 28 ++++++++++++++++++++--------
+ result/catalogs/recursive      |  1 +
+ test/catalogs/recursive.script |  0
+ test/catalogs/recursive.sgml   |  1 +
+ 4 files changed, 22 insertions(+), 8 deletions(-)
+ create mode 100644 result/catalogs/recursive
+ create mode 100644 test/catalogs/recursive.script
+ create mode 100644 test/catalogs/recursive.sgml
+
+diff --git a/catalog.c b/catalog.c
+index 7328fd31..ae1407b7 100644
+--- a/catalog.c
++++ b/catalog.c
+@@ -92,7 +92,7 @@ unsigned long __stdcall GetModuleFileNameA(void*, char*, unsigned long);
+ #endif
+ 
+ static xmlChar *xmlCatalogNormalizePublic(const xmlChar *pubID);
+-static int xmlExpandCatalog(xmlCatalogPtr catal, const char *filename);
++static int xmlExpandCatalog(xmlCatalogPtr catal, const char *filename, int depth);
+ 
+ /************************************************************************
+  *									*
+@@ -2320,6 +2320,7 @@ xmlGetSGMLCatalogEntryType(const xmlChar *name) {
+  * @file:  the filepath for the catalog
+  * @super:  should this be handled as a Super Catalog in which case
+  *          parsing is not recursive
++ * @depth:  the current depth of the catalog
+  *
+  * Parse an SGML catalog content and fill up the @catal hash table with
+  * the new entries found.
+@@ -2328,13 +2329,19 @@ xmlGetSGMLCatalogEntryType(const xmlChar *name) {
+  */
+ static int
+ xmlParseSGMLCatalog(xmlCatalogPtr catal, const xmlChar *value,
+-	            const char *file, int super) {
++	            const char *file, int super, int depth) {
+     const xmlChar *cur = value;
+     xmlChar *base = NULL;
+     int res;
+ 
+     if ((cur == NULL) || (file == NULL))
+         return(-1);
++
++    /* Check recursion depth */
++    if (depth > MAX_CATAL_DEPTH) {
++        return(-1);
++    }
++
+     base = xmlStrdup((const xmlChar *) file);
+ 
+     while ((cur != NULL) && (cur[0] != 0)) {
+@@ -2511,7 +2518,7 @@ xmlParseSGMLCatalog(xmlCatalogPtr catal, const xmlChar *value,
+ 
+ 		    filename = xmlBuildURI(sysid, base);
+ 		    if (filename != NULL) {
+-			xmlExpandCatalog(catal, (const char *)filename);
++			xmlExpandCatalog(catal, (const char *)filename, depth);
+ 			xmlFree(filename);
+ 		    }
+ 		}
+@@ -2661,7 +2668,7 @@ xmlLoadSGMLSuperCatalog(const char *filename)
+ 	return(NULL);
+     }
+ 
+-    ret = xmlParseSGMLCatalog(catal, content, filename, 1);
++    ret = xmlParseSGMLCatalog(catal, content, filename, 1, 0);
+     xmlFree(content);
+     if (ret < 0) {
+ 	xmlFreeCatalog(catal);
+@@ -2707,7 +2714,7 @@ xmlLoadACatalog(const char *filename)
+ 	    xmlFree(content);
+ 	    return(NULL);
+ 	}
+-        ret = xmlParseSGMLCatalog(catal, content, filename, 0);
++        ret = xmlParseSGMLCatalog(catal, content, filename, 0, 0);
+ 	if (ret < 0) {
+ 	    xmlFreeCatalog(catal);
+ 	    xmlFree(content);
+@@ -2730,6 +2737,7 @@ xmlLoadACatalog(const char *filename)
+  * xmlExpandCatalog:
+  * @catal:  a catalog
+  * @filename:  a file path
++ * @depth:  the current depth of the catalog
+  *
+  * Load the catalog and expand the existing catal structure.
+  * This can be either an XML Catalog or an SGML Catalog
+@@ -2737,13 +2745,17 @@ xmlLoadACatalog(const char *filename)
+  * Returns 0 in case of success, -1 in case of error
+  */
+ static int
+-xmlExpandCatalog(xmlCatalogPtr catal, const char *filename)
++xmlExpandCatalog(xmlCatalogPtr catal, const char *filename, int depth)
+ {
+     int ret;
+ 
+     if ((catal == NULL) || (filename == NULL))
+ 	return(-1);
+ 
++    /* Check recursion depth */
++    if (depth > MAX_CATAL_DEPTH) {
++	return(-1);
++    }
+ 
+     if (catal->type == XML_SGML_CATALOG_TYPE) {
+ 	xmlChar *content;
+@@ -2752,7 +2764,7 @@ xmlExpandCatalog(xmlCatalogPtr catal, const char *filename)
+ 	if (content == NULL)
+ 	    return(-1);
+ 
+-        ret = xmlParseSGMLCatalog(catal, content, filename, 0);
++        ret = xmlParseSGMLCatalog(catal, content, filename, 0, depth + 1);
+ 	if (ret < 0) {
+ 	    xmlFree(content);
+ 	    return(-1);
+@@ -3220,7 +3232,7 @@ xmlLoadCatalog(const char *filename)
+ 	return(0);
+     }
+ 
+-    ret = xmlExpandCatalog(xmlDefaultCatalog, filename);
++    ret = xmlExpandCatalog(xmlDefaultCatalog, filename, 0);
+     xmlRMutexUnlock(xmlCatalogMutex);
+     return(ret);
+ }
+diff --git a/result/catalogs/recursive b/result/catalogs/recursive
+new file mode 100644
+index 00000000..56ca91ea
+--- /dev/null
++++ b/result/catalogs/recursive
+@@ -0,0 +1 @@
++> 
+\ No newline at end of file
+diff --git a/test/catalogs/recursive.script b/test/catalogs/recursive.script
+new file mode 100644
+index 00000000..e69de29b
+diff --git a/test/catalogs/recursive.sgml b/test/catalogs/recursive.sgml
+new file mode 100644
+index 00000000..ac2148be
+--- /dev/null
++++ b/test/catalogs/recursive.sgml
+@@ -0,0 +1 @@
++CATALOG recursive.sgml
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/libxml/libxml2/CVE-2026-0989.patch
+++ b/meta-core/recipes-core/libxml/libxml2/CVE-2026-0989.patch
@@ -1,0 +1,316 @@
+From edca67ca1469132ba2b15000e1ce53c3d1d41944 Mon Sep 17 00:00:00 2001
+From: Daniel Garcia Moreno <daniel.garcia@suse.com>
+Date: Fri, 10 Oct 2025 09:38:31 +0200
+Subject: [PATCH] Add RelaxNG include limit
+
+This patch adds a default xmlRelaxNGIncludeLimit of 1.000, and that
+limit can be modified at runtime with the env variable
+RNG_INCLUDE_LIMIT.
+
+Origin: https://gitlab.gnome.org/GNOME/libxml2/-/commit/66c52b3ac6c32ab112ec2a3bf41e6c30948be113
+Bug: https://gitlab.gnome.org/GNOME/libxml2/-/issues/998
+Bug: https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/374
+Bug-Debian-Security: https://deb.freexian.com/extended-lts/tracker/CVE-2026-0989
+Bug-Debian: https://bugs.debian.org/1125691
+
+CVE: CVE-2026-0989
+Upstream-Status: Backport[https://gitlab.gnome.org/GNOME/libxml2/-/commit/66c52b3ac6c32ab112ec2a3bf41e6c30948be113]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ include/libxml/relaxng.h                 |  4 ++
+ relaxng.c                                | 63 ++++++++++++++++++++--
+ runtest.c                                | 67 ++++++++++++++++++++++++
+ test/relaxng/include/include-limit.rng   |  4 ++
+ test/relaxng/include/include-limit_1.rng |  4 ++
+ test/relaxng/include/include-limit_2.rng |  4 ++
+ test/relaxng/include/include-limit_3.rng |  8 +++
+ 7 files changed, 150 insertions(+), 4 deletions(-)
+ create mode 100644 test/relaxng/include/include-limit.rng
+ create mode 100644 test/relaxng/include/include-limit_1.rng
+ create mode 100644 test/relaxng/include/include-limit_2.rng
+ create mode 100644 test/relaxng/include/include-limit_3.rng
+
+diff --git a/include/libxml/relaxng.h b/include/libxml/relaxng.h
+index f269c9ec..d5216791 100644
+--- a/include/libxml/relaxng.h
++++ b/include/libxml/relaxng.h
+@@ -138,6 +138,10 @@ XMLPUBFUN int XMLCALL
+ 
+ XMLPUBFUN void XMLCALL
+ 		    xmlRelaxNGFreeParserCtxt	(xmlRelaxNGParserCtxtPtr ctxt);
++XMLPUBFUN int XMLCALL
++		    xmlRelaxParserSetIncLImit	(xmlRelaxNGParserCtxtPtr ctxt,
++						 int limit);
++
+ XMLPUBFUN void XMLCALL
+ 		    xmlRelaxNGSetParserErrors(xmlRelaxNGParserCtxtPtr ctxt,
+ 					 xmlRelaxNGValidityErrorFunc err,
+diff --git a/relaxng.c b/relaxng.c
+index 13fd954c..395adc5d 100644
+--- a/relaxng.c
++++ b/relaxng.c
+@@ -18,6 +18,8 @@
+ 
+ #ifdef LIBXML_SCHEMAS_ENABLED
+ 
++#include <errno.h>
++#include <stdlib.h>
+ #include <string.h>
+ #include <stdio.h>
+ #include <stddef.h>
+@@ -40,6 +42,12 @@
+ static const xmlChar *xmlRelaxNGNs = (const xmlChar *)
+     "http://relaxng.org/ns/structure/1.0";
+ 
++/*
++ * Default include limit, this can be override with RNG_INCLUDE_LIMIT
++ * env variable
++ */
++static const int _xmlRelaxNGIncludeLimit = 1000;
++
+ #define IS_RELAXNG(node, typ)						\
+    ((node != NULL) && (node->ns != NULL) &&				\
+     (node->type == XML_ELEMENT_NODE) &&					\
+@@ -245,6 +253,7 @@ struct _xmlRelaxNGParserCtxt {
+     int incNr;                  /* Depth of the include parsing stack */
+     int incMax;                 /* Max depth of the parsing stack */
+     xmlRelaxNGIncludePtr *incTab;       /* array of incs */
++    int incLimit;               /* Include limit, to avoid stack-overflow on parse */
+ 
+     int idref;                  /* requires idref checking */
+ 
+@@ -1430,6 +1439,23 @@ xmlRelaxParserSetFlag(xmlRelaxNGParserCtxtPtr ctxt, int flags)
+     return(0);
+ }
+ 
++/**
++ * Semi private function used to set the include recursion limit to a
++ * parser context. Set to 0 to use the default value.
++ *
++ * @param ctxt  a RelaxNG parser context
++ * @param limit the new include depth limit
++ * @returns 0 if success and -1 in case of error
++ */
++int
++xmlRelaxParserSetIncLImit(xmlRelaxNGParserCtxtPtr ctxt, int limit)
++{
++    if (ctxt == NULL) return(-1);
++    if (limit < 0) return(-1);
++    ctxt->incLimit = limit;
++    return(0);
++}
++
+ /************************************************************************
+  *									*
+  *			Document functions				*
+@@ -1445,7 +1471,7 @@ static xmlDocPtr xmlRelaxNGCleanupDoc(xmlRelaxNGParserCtxtPtr ctxt,
+  *
+  * Pushes a new include on top of the include stack
+  *
+- * Returns 0 in case of error, the index in the stack otherwise
++ * Returns -1 in case of error, the index in the stack otherwise
+  */
+ static int
+ xmlRelaxNGIncludePush(xmlRelaxNGParserCtxtPtr ctxt,
+@@ -1459,9 +1485,15 @@ xmlRelaxNGIncludePush(xmlRelaxNGParserCtxtPtr ctxt,
+                                                sizeof(ctxt->incTab[0]));
+         if (ctxt->incTab == NULL) {
+             xmlRngPErrMemory(ctxt, "allocating include\n");
+-            return (0);
++            return (-1);
+         }
+     }
++    if (ctxt->incNr >= ctxt->incLimit) {
++        xmlRngPErr(ctxt, (xmlNodePtr)value->doc, XML_RNGP_PARSE_ERROR,
++                   "xmlRelaxNG: inclusion recursion limit reached\n", NULL, NULL);
++        return(-1);
++    }
++
+     if (ctxt->incNr >= ctxt->incMax) {
+         ctxt->incMax *= 2;
+         ctxt->incTab =
+@@ -1470,7 +1502,7 @@ xmlRelaxNGIncludePush(xmlRelaxNGParserCtxtPtr ctxt,
+                                                 sizeof(ctxt->incTab[0]));
+         if (ctxt->incTab == NULL) {
+             xmlRngPErrMemory(ctxt, "allocating include\n");
+-            return (0);
++            return (-1);
+         }
+     }
+     ctxt->incTab[ctxt->incNr] = value;
+@@ -1664,7 +1696,9 @@ xmlRelaxNGLoadInclude(xmlRelaxNGParserCtxtPtr ctxt, const xmlChar * URL,
+     /*
+      * push it on the stack
+      */
+-    xmlRelaxNGIncludePush(ctxt, ret);
++    if (xmlRelaxNGIncludePush(ctxt, ret) < 0) {
++        return (NULL);
++    }
+ 
+     /*
+      * Some preprocessing of the document content, this include recursing
+@@ -7509,11 +7543,32 @@ xmlRelaxNGParse(xmlRelaxNGParserCtxtPtr ctxt)
+     xmlDocPtr doc;
+     xmlNodePtr root;
+ 
++    const char *include_limit_env = getenv("RNG_INCLUDE_LIMIT");
++
+     xmlRelaxNGInitTypes();
+ 
+     if (ctxt == NULL)
+         return (NULL);
+ 
++    if (ctxt->incLimit == 0) {
++        ctxt->incLimit = _xmlRelaxNGIncludeLimit;
++        if (include_limit_env != NULL) {
++            char *strEnd;
++            unsigned long val = 0;
++            errno = 0;
++            val = strtoul(include_limit_env, &strEnd, 10);
++            if (errno != 0 || *strEnd != 0 || val > INT_MAX) {
++                xmlRngPErr(ctxt, NULL, XML_RNGP_PARSE_ERROR,
++                           "xmlRelaxNGParse: invalid RNG_INCLUDE_LIMIT %s\n",
++                           (const xmlChar*)include_limit_env,
++                           NULL);
++                return(NULL);
++            }
++            if (val)
++                ctxt->incLimit = val;
++        }
++    }
++
+     /*
+      * First step is to parse the input document into an DOM/Infoset
+      */
+diff --git a/runtest.c b/runtest.c
+index 470f95cb..3febc49d 100644
+--- a/runtest.c
++++ b/runtest.c
+@@ -3315,6 +3315,70 @@ rngTest(const char *filename,
+     return(ret);
+ }
+ 
++/**
++ * Parse an RNG schemas with a custom RNG_INCLUDE_LIMIT
++ *
++ * @param filename  the schemas file
++ * @param result  the file with expected result
++ * @param err  the file with error messages
++ * @returns 0 in case of success, an error code otherwise
++ */
++static int
++rngIncludeTest(const char *filename,
++               const char *resul ATTRIBUTE_UNUSED,
++               const char *errr ATTRIBUTE_UNUSED,
++               int options ATTRIBUTE_UNUSED) {
++    xmlRelaxNGParserCtxtPtr ctxt;
++    xmlRelaxNGPtr schemas;
++    int ret = 0;
++
++    /* first compile the schemas if possible */
++    ctxt = xmlRelaxNGNewParserCtxt(filename);
++    xmlRelaxNGSetParserStructuredErrors(ctxt, testStructuredErrorHandler,
++                                        NULL);
++
++    /* Should work */
++    schemas = xmlRelaxNGParse(ctxt);
++    if (schemas == NULL) {
++        testErrorHandler(NULL, "Relax-NG schema %s failed to compile\n",
++                         filename);
++        ret = -1;
++        goto done;
++    }
++    xmlRelaxNGFree(schemas);
++    xmlRelaxNGFreeParserCtxt(ctxt);
++
++    ctxt = xmlRelaxNGNewParserCtxt(filename);
++    /* Should fail */
++    xmlRelaxParserSetIncLImit(ctxt, 2);
++    xmlRelaxNGSetParserStructuredErrors(ctxt, testStructuredErrorHandler,
++                                        NULL);
++    schemas = xmlRelaxNGParse(ctxt);
++    if (schemas != NULL) {
++        ret = -1;
++        xmlRelaxNGFree(schemas);
++    }
++    xmlRelaxNGFreeParserCtxt(ctxt);
++
++    ctxt = xmlRelaxNGNewParserCtxt(filename);
++    /* Should work */
++    xmlRelaxParserSetIncLImit(ctxt, 3);
++    xmlRelaxNGSetParserStructuredErrors(ctxt, testStructuredErrorHandler,
++                                        NULL);
++    schemas = xmlRelaxNGParse(ctxt);
++    if (schemas == NULL) {
++        testErrorHandler(NULL, "Relax-NG schema %s failed to compile\n",
++                         filename);
++        ret = -1;
++        goto done;
++    }
++    xmlRelaxNGFree(schemas);
++
++done:
++    xmlRelaxNGFreeParserCtxt(ctxt);
++    return(ret);
++}
++
+ #ifdef LIBXML_READER_ENABLED
+ /**
+  * rngStreamTest:
+@@ -4372,6 +4436,9 @@ testDesc testDescriptions[] = {
+     { "Relax-NG regression tests" ,
+       rngTest, "./test/relaxng/*.rng", NULL, NULL, NULL,
+       XML_PARSE_DTDATTR | XML_PARSE_NOENT },
++    { "Relax-NG include limit tests" ,
++      rngIncludeTest, "./test/relaxng/include/include-limit.rng", NULL, NULL, NULL,
++      0 },
+ #ifdef LIBXML_READER_ENABLED
+     { "Relax-NG streaming regression tests" ,
+       rngStreamTest, "./test/relaxng/*.rng", NULL, NULL, NULL,
+diff --git a/test/relaxng/include/include-limit.rng b/test/relaxng/include/include-limit.rng
+new file mode 100644
+index 00000000..51f03942
+--- /dev/null
++++ b/test/relaxng/include/include-limit.rng
+@@ -0,0 +1,4 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<grammar xmlns="http://relaxng.org/ns/structure/1.0">
++    <include href="include-limit_1.rng"/>
++</grammar>
+diff --git a/test/relaxng/include/include-limit_1.rng b/test/relaxng/include/include-limit_1.rng
+new file mode 100644
+index 00000000..4672da38
+--- /dev/null
++++ b/test/relaxng/include/include-limit_1.rng
+@@ -0,0 +1,4 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<grammar xmlns="http://relaxng.org/ns/structure/1.0">
++    <include href="include-limit_2.rng"/>
++</grammar>
+diff --git a/test/relaxng/include/include-limit_2.rng b/test/relaxng/include/include-limit_2.rng
+new file mode 100644
+index 00000000..b35ecaa8
+--- /dev/null
++++ b/test/relaxng/include/include-limit_2.rng
+@@ -0,0 +1,4 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<grammar xmlns="http://relaxng.org/ns/structure/1.0">
++    <include href="include-limit_3.rng"/>
++</grammar>
+diff --git a/test/relaxng/include/include-limit_3.rng b/test/relaxng/include/include-limit_3.rng
+new file mode 100644
+index 00000000..86213c62
+--- /dev/null
++++ b/test/relaxng/include/include-limit_3.rng
+@@ -0,0 +1,8 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<grammar xmlns="http://relaxng.org/ns/structure/1.0">
++    <start>
++        <element name="root">
++            <empty/>
++        </element>
++    </start>
++</grammar>
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/libxml/libxml2/CVE-2026-0990.patch
+++ b/meta-core/recipes-core/libxml/libxml2/CVE-2026-0990.patch
@@ -1,0 +1,82 @@
+From 998093df5afc1f874f88adb306b58237cd438360 Mon Sep 17 00:00:00 2001
+From: Daniel Garcia Moreno <daniel.garcia@suse.com>
+Date: Wed, 17 Dec 2025 15:24:08 +0100
+Subject: [PATCH] catalog: prevent inf recursion in xmlCatalogXMLResolveURI
+
+Origin: https://gitlab.gnome.org/GNOME/libxml2/-/commit/ac6f0fde1476c41f59ad0c68ada3394599ebf2ae
+Bug: https://gitlab.gnome.org/GNOME/libxml2/-/issues/1018
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2026-0990
+Bug-Debian: https://bugs.debian.org/1125695
+
+CVE: CVE-2026-0990
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/libxml2/-/commit/ac6f0fde1476c41f59ad0c68ada3394599ebf2ae]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ catalog.c | 31 +++++++++++++++++++++++--------
+ 1 file changed, 23 insertions(+), 8 deletions(-)
+
+diff --git a/catalog.c b/catalog.c
+index ae1407b7..111b35e6 100644
+--- a/catalog.c
++++ b/catalog.c
+@@ -2099,12 +2099,21 @@ static xmlChar *
+ xmlCatalogListXMLResolveURI(xmlCatalogEntryPtr catal, const xmlChar *URI) {
+     xmlChar *ret = NULL;
+     xmlChar *urnID = NULL;
++    xmlCatalogEntryPtr cur = NULL;
+ 
+     if (catal == NULL)
+         return(NULL);
+     if (URI == NULL)
+ 	return(NULL);
+ 
++    if (catal->depth > MAX_CATAL_DEPTH) {
++	xmlCatalogErr(catal, NULL, XML_CATALOG_RECURSION,
++		      "Detected recursion in catalog %s\n",
++		      catal->name, NULL, NULL);
++	return(NULL);
++    }
++    catal->depth++;
++
+     if (!xmlStrncmp(URI, BAD_CAST XML_URN_PUBID, sizeof(XML_URN_PUBID) - 1)) {
+ 	urnID = xmlCatalogUnWrapURN(URI);
+ 	if (xmlDebugCatalogs) {
+@@ -2118,21 +2127,27 @@ xmlCatalogListXMLResolveURI(xmlCatalogEntryPtr catal, const xmlChar *URI) {
+ 	ret = xmlCatalogListXMLResolve(catal, urnID, NULL);
+ 	if (urnID != NULL)
+ 	    xmlFree(urnID);
++	catal->depth--;
+ 	return(ret);
+     }
+-    while (catal != NULL) {
+-	if (catal->type == XML_CATA_CATALOG) {
+-	    if (catal->children == NULL) {
+-		xmlFetchXMLCatalogFile(catal);
++    cur = catal;
++    while (cur != NULL) {
++	if (cur->type == XML_CATA_CATALOG) {
++	    if (cur->children == NULL) {
++		xmlFetchXMLCatalogFile(cur);
+ 	    }
+-	    if (catal->children != NULL) {
+-		ret = xmlCatalogXMLResolveURI(catal->children, URI);
+-		if (ret != NULL)
++	    if (cur->children != NULL) {
++		ret = xmlCatalogXMLResolveURI(cur->children, URI);
++		if (ret != NULL) {
++		    catal->depth--;
+ 		    return(ret);
++		}
+ 	    }
+ 	}
+-	catal = catal->next;
++	cur = cur->next;
+     }
++
++    catal->depth--;
+     return(ret);
+ }
+ 
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/libxml/libxml2/CVE-2026-0992-01.patch
+++ b/meta-core/recipes-core/libxml/libxml2/CVE-2026-0992-01.patch
@@ -1,0 +1,55 @@
+From 94ae32a7b13651bef5e986430ddc1f8f211fb724 Mon Sep 17 00:00:00 2001
+From: Daniel Garcia Moreno <daniel.garcia@suse.com>
+Date: Fri, 19 Dec 2025 11:02:18 +0100
+Subject: [PATCH 1/2] catalog: Ignore repeated nextCatalog entries
+
+This patch makes the catalog parsing to ignore repeated entries of
+nextCatalog with the same value.
+
+Origin: https://gitlab.gnome.org/GNOME/libxml2/-/commit/4af23b523de5b72f27faf3e8e8a99dde5f7b82a2
+Bug: https://gitlab.gnome.org/GNOME/libxml2/-/issues/1019
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2026-0992
+Bug-Debian: https://bugs.debian.org/1125696
+
+CVE: CVE-2026-0992
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/libxml2/-/commit/4af23b523de5b72f27faf3e8e8a99dde5f7b82a2]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ catalog.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/catalog.c b/catalog.c
+index 111b35e6..644c0433 100644
+--- a/catalog.c
++++ b/catalog.c
+@@ -1278,9 +1278,27 @@ xmlParseXMLCatalogNode(xmlNodePtr cur, xmlCatalogPrefer prefer,
+ 		BAD_CAST "delegateURI", BAD_CAST "uriStartString",
+ 		BAD_CAST "catalog", prefer, cgroup);
+     } else if (xmlStrEqual(cur->name, BAD_CAST "nextCatalog")) {
++	xmlCatalogEntryPtr prev = parent->children;
++
+ 	entry = xmlParseXMLCatalogOneNode(cur, XML_CATA_NEXT_CATALOG,
+ 		BAD_CAST "nextCatalog", NULL,
+ 		BAD_CAST "catalog", prefer, cgroup);
++	/* Avoid duplication of nextCatalog */
++	while (prev != NULL) {
++	    if ((prev->type == XML_CATA_NEXT_CATALOG) &&
++		(xmlStrEqual (prev->URL, entry->URL)) &&
++		(xmlStrEqual (prev->value, entry->value)) &&
++		(prev->prefer == entry->prefer) &&
++		(prev->group == entry->group)) {
++		    if (xmlDebugCatalogs)
++			fprintf(stderr,
++			    "Ignoring repeated nextCatalog %s\n", entry->URL);
++		    xmlFreeCatalogEntry(entry, NULL);
++		    entry = NULL;
++		    break;
++	    }
++	    prev = prev->next;
++	}
+     }
+     if (entry != NULL) {
+         if (parent != NULL) {
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/libxml/libxml2/CVE-2026-0992-02.patch
+++ b/meta-core/recipes-core/libxml/libxml2/CVE-2026-0992-02.patch
@@ -1,0 +1,39 @@
+From ee7698e8785153ab8c4142b4de835403979897b1 Mon Sep 17 00:00:00 2001
+From: Daniel Garcia Moreno <dani@danigm.net>
+Date: Sun, 18 Jan 2026 19:47:11 +0100
+Subject: [PATCH 2/2] catalog: Do not check value for duplication nextCatalog
+
+The value field stores the path as it appears in the catalog definition,
+the URL is built using xmlBuildURI that changes the relative paths to
+absolute.
+
+This change fixes the issue of using relative path to the same catalog
+in the same file.
+
+Origin: https://gitlab.gnome.org/GNOME/libxml2/-/commit/096402c942e9d9a049f283eb4e6da431289900e1
+Bug: https://gitlab.gnome.org/GNOME/libxml2/-/issues/1040
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2026-0992
+Bug-Debian: https://bugs.debian.org/1125696
+
+CVE: CVE-2026-0992
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/libxml2/-/commit/096402c942e9d9a049f283eb4e6da431289900e1]
+Signed-off-by: Brett Werling <bwerl.dev@gmail.com>
+---
+ catalog.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/catalog.c b/catalog.c
+index 644c0433..d79d1020 100644
+--- a/catalog.c
++++ b/catalog.c
+@@ -1287,7 +1287,6 @@ xmlParseXMLCatalogNode(xmlNodePtr cur, xmlCatalogPrefer prefer,
+ 	while (prev != NULL) {
+ 	    if ((prev->type == XML_CATA_NEXT_CATALOG) &&
+ 		(xmlStrEqual (prev->URL, entry->URL)) &&
+-		(xmlStrEqual (prev->value, entry->value)) &&
+ 		(prev->prefer == entry->prefer) &&
+ 		(prev->group == entry->group)) {
+ 		    if (xmlDebugCatalogs)
+-- 
+2.54.0
+

--- a/meta-core/recipes-core/libxml/libxml2_2.9.10.bbappend
+++ b/meta-core/recipes-core/libxml/libxml2_2.9.10.bbappend
@@ -11,4 +11,5 @@ SRC_URI_append = " \
     file://CVE-2022-49043.patch \
     file://CVE-2025-9714.patch \
     file://CVE-2025-8732.patch \
+    file://CVE-2026-0989.patch \
     "

--- a/meta-core/recipes-core/libxml/libxml2_2.9.10.bbappend
+++ b/meta-core/recipes-core/libxml/libxml2_2.9.10.bbappend
@@ -12,4 +12,5 @@ SRC_URI_append = " \
     file://CVE-2025-9714.patch \
     file://CVE-2025-8732.patch \
     file://CVE-2026-0989.patch \
+    file://CVE-2026-0990.patch \
     "

--- a/meta-core/recipes-core/libxml/libxml2_2.9.10.bbappend
+++ b/meta-core/recipes-core/libxml/libxml2_2.9.10.bbappend
@@ -13,4 +13,6 @@ SRC_URI_append = " \
     file://CVE-2025-8732.patch \
     file://CVE-2026-0989.patch \
     file://CVE-2026-0990.patch \
+    file://CVE-2026-0992-01.patch \
+    file://CVE-2026-0992-02.patch \
     "

--- a/meta-core/recipes-core/libxml/libxml2_2.9.10.bbappend
+++ b/meta-core/recipes-core/libxml/libxml2_2.9.10.bbappend
@@ -10,4 +10,5 @@ SRC_URI_append = " \
     file://CVE-2025-6021.patch \
     file://CVE-2022-49043.patch \
     file://CVE-2025-9714.patch \
+    file://CVE-2025-8732.patch \
     "


### PR DESCRIPTION
Backports several CVE fixes for libxml2 from Debian:
* CVE-2025-8732
* CVE-2026-0989
* CVE-2026-0990
* CVE-2026-0992