### PR TITLE
Add Systemd testing (Dunfell)

### DIFF
--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -12,6 +12,11 @@ on:  # yamllint disable-line rule:truthy
         default: 'core-image-minimal'
         required: false
         type: string
+      use-systemd:
+        description: 'If Systemd should be used or not'
+        default: false
+        required: false
+        type: boolean
       only-build-modified:
         description: 'If true, bitbake will only build the recipes that are affected by the PR'
         required: true
@@ -145,6 +150,14 @@ jobs:
           echo "require $GITHUB_WORKSPACE/meta-lts-collab/conf/ci.conf" >> "$AUTO_CONF"
           printf "CORE_IMAGE_EXTRA_INSTALL = \" %s\"\n" \
             "${{ steps.targets.outputs.image_targets }}" >> "$AUTO_CONF"
+
+          # Optional: Add Systemd configuration
+          if [ "${{ inputs.use-systemd }}" = "true" ]; then
+            echo "DISTRO_FEATURES:append = \" systemd usrmerge\"" >> "$AUTO_CONF"
+            echo "DISTRO_FEATURES_BACKFILL_CONSIDERED += \"sysvinit\"" >> "$AUTO_CONF"
+            echo "VIRTUAL-RUNTIME_init_manager = \"systemd\"" >> "$AUTO_CONF"
+            echo "VIRTUAL-RUNTIME_initscripts = \"systemd-compat-units\"" >> "$AUTO_CONF"
+          fi
 
           # Verify auto.conf configuration
           echo "## $AUTO_CONF configuration ##"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,10 @@ jobs:
       use-cache: false
 
   build:
-    name: 'Build and test recipes'
+    name: 'Build and test recipes (Systemd: ${{ matrix.systemd }})'
+    strategy:
+      matrix:
+        systemd: [true, false]
     needs: parse
     uses: ./.github/workflows/bitbake-common.yml
     with:
@@ -33,3 +36,4 @@ jobs:
       parse-only: false
       run-tests: true
       runner: yocto_build_host
+      use-systemd: ${{ matrix.systemd }}

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -25,6 +25,9 @@ jobs:
       use-cache: false
 
   build:
+    strategy:
+      matrix:
+        systemd: [true, false]
     needs: parse
     uses: ./.github/workflows/bitbake-common.yml
     with:
@@ -35,3 +38,4 @@ jobs:
       runner: yocto_build_host
       save-cache: true
       use-cache: true
+      use-systemd: ${{ matrix.systemd }}

--- a/scripts/get-bitbake-targets.py
+++ b/scripts/get-bitbake-targets.py
@@ -98,10 +98,14 @@ def get_bpns(
     """
     bpns = get_modified_bpns(modified_files) if modified_files else get_all_bpns()
     if bpn_filter == BPNFilter.NATIVE:
-        return list(filter(lambda bpn: bpn.rstrip("-native") in NATIVE_ONLY_BPNS, bpns))
+        return list(
+            filter(lambda bpn: bpn.removesuffix("-native") in NATIVE_ONLY_BPNS, bpns)
+        )
     elif bpn_filter == BPNFilter.IMAGE:
         return list(
-            filter(lambda bpn: bpn.rstrip("-native") not in NATIVE_ONLY_BPNS, bpns)
+            filter(
+                lambda bpn: bpn.removesuffix("-native") not in NATIVE_ONLY_BPNS, bpns
+            )
         )
     return bpns
 

--- a/scripts/get-bitbake-targets.py
+++ b/scripts/get-bitbake-targets.py
@@ -97,6 +97,11 @@ def get_bpns(
         List[str]: All BPNs in the layer, or all associated BPNs if modified files are provided
     """
     bpns = get_modified_bpns(modified_files) if modified_files else get_all_bpns()
+
+    # We never want Systemd in the list of bpns
+    if "systemd" in bpns:
+        bpns.remove("systemd")
+
     if bpn_filter == BPNFilter.NATIVE:
         return list(
             filter(lambda bpn: bpn.removesuffix("-native") in NATIVE_ONLY_BPNS, bpns)


### PR DESCRIPTION
Ensures a systemd test image is also built and tested in addition to the current sysvinit image.

Fixes https://github.com/garmin/meta-lts-collab/issues/169