### PR TITLE
glibc: Ignore CVE-2026-6238 (kirkstone)

### DIFF
--- a/meta-core/recipes-core/glibc/glibc_2.35.bbappend
+++ b/meta-core/recipes-core/glibc/glibc_2.35.bbappend
@@ -13,3 +13,11 @@ SRC_URI:append = " \
 # The fix was backported upstream as commit
 # 6bcd5d8e3668d52388a6e0580611749f93e6871f
 CVE_CHECK_IGNORE += "CVE-2026-3904"
+
+# glibc https://nvd.nist.gov/vuln/detail/CVE-2026-6238
+# Affects deprecated debugging functions in the GNU C Library
+#
+# These functions are for application debugging only and hence not in the
+# path of code executed by the DNS resolver.
+# https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=advisories/GLIBC-SA-2026-0012
+CVE_CHECK_IGNORE += "CVE-2026-6238"


### PR DESCRIPTION
CVE-2026-6238 affects deprecated debugging functions in the GNU C Library

These functions are for application debugging only and hence not in the path of code executed by the DNS resolver.
Further, they have been deprecated since version 2.34

https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=advisories/GLIBC-SA-2026-0012 https://nvd.nist.gov/vuln/detail/CVE-2026-6238