### PR TITLE
glibc: Ignore CVE-2026-6238, CVE-2026-5435 (dunfell)

### DIFF
--- a/meta-core/recipes-core/glibc/glibc_2.31%.bbappend
+++ b/meta-core/recipes-core/glibc/glibc_2.31%.bbappend
@@ -17,3 +17,13 @@ SRC_URI_append = " \
     file://CVE-2026-5450.patch \
     file://CVE-2026-5928.patch \
     "
+
+# glibc https://nvd.nist.gov/vuln/detail/CVE-2026-6238
+# glibc https://nvd.nist.gov/vuln/detail/CVE-2026-5435
+# Affects deprecated debugging functions in the GNU C Library
+#
+# These functions are for application debugging only and hence not in the
+# path of code executed by the DNS resolver.
+# https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=advisories/GLIBC-SA-2026-0012
+# https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=advisories/GLIBC-SA-2026-0011
+CVE_CHECK_WHITELIST += "CVE-2026-6238 CVE-2026-5435"


### PR DESCRIPTION
CVE-2026-6238 and CVE-2026-5435 affect deprecated debugging functions in the GNU C Library.

These functions are for application debugging only and hence not in the path of code executed by the DNS resolver.

https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=advisories/GLIBC-SA-2026-0012 https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=advisories/GLIBC-SA-2026-0011

https://nvd.nist.gov/vuln/detail/CVE-2026-6238
https://nvd.nist.gov/vuln/detail/CVE-2026-5435