### PR TITLE
tiff: fix CVE-2026-4775 (kirkstone)

### DIFF
--- a/meta-core/recipes-multimedia/libtiff/files/CVE-2026-4775.patch
+++ b/meta-core/recipes-multimedia/libtiff/files/CVE-2026-4775.patch
@@ -1,0 +1,55 @@
+From 8e238a644be045b19fa518705a3e25e1c57cc2f1 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sun, 22 Feb 2026 23:32:47 +0100
+Subject: [PATCH] TIFFReadRGBAImage(): prevent integer overflow and later heap
+ overflow on images with huge width in YCbCr tile decoding functions
+
+Fixes https://gitlab.com/libtiff/libtiff/-/issues/787
+
+CVE: CVE-2026-4775
+Upstream-Status: Backport [https://gitlab.com/libtiff/libtiff/-/commit/782a11d6b5b61c6dc21e714950a4af5bf89f023c]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ libtiff/tif_getimage.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libtiff/tif_getimage.c b/libtiff/tif_getimage.c
+index e1189575..8def49e9 100644
+--- a/libtiff/tif_getimage.c
++++ b/libtiff/tif_getimage.c
+@@ -1914,7 +1914,7 @@ DECLAREContigPutFunc(putcontig8bitYCbCr44tile)
+     uint32_t* cp1 = cp + w + toskew;
+     uint32_t* cp2 = cp1 + w + toskew;
+     uint32_t* cp3 = cp2 + w + toskew;
+-    int32_t incr = 3 * w + 4 * toskew;
++    const tmsize_t incr = 3 * (tmsize_t)w + 4 * (tmsize_t)toskew;
+ 
+     (void) y;
+     /* adjust fromskew */
+@@ -2018,7 +2018,7 @@ DECLAREContigPutFunc(putcontig8bitYCbCr44tile)
+ DECLAREContigPutFunc(putcontig8bitYCbCr42tile)
+ {
+     uint32_t* cp1 = cp + w + toskew;
+-    int32_t incr = 2 * toskew + w;
++    const tmsize_t incr = 2 * (tmsize_t)toskew + w;
+ 
+     (void) y;
+     fromskew = (fromskew / 4) * (4*2+2);
+@@ -2144,7 +2144,7 @@ DECLAREContigPutFunc(putcontig8bitYCbCr41tile)
+ DECLAREContigPutFunc(putcontig8bitYCbCr22tile)
+ {
+ 	uint32_t* cp2;
+-	int32_t incr = 2 * toskew + w;
++	const tmsize_t incr = 2 * (tmsize_t)toskew + w;
+ 	(void) y;
+ 	fromskew = (fromskew / 2) * (2*2+2);
+ 	cp2 = cp+w+toskew;
+@@ -2239,7 +2239,7 @@ DECLAREContigPutFunc(putcontig8bitYCbCr21tile)
+ DECLAREContigPutFunc(putcontig8bitYCbCr12tile)
+ {
+ 	uint32_t* cp2;
+-	int32_t incr = 2 * toskew + w;
++	const tmsize_t incr = 2 * (tmsize_t)toskew + w;
+ 	(void) y;
+ 	fromskew = (fromskew / 1) * (1 * 2 + 2);
+ 	cp2 = cp+w+toskew;

--- a/meta-core/recipes-multimedia/libtiff/tiff_4.3.0.bbappend
+++ b/meta-core/recipes-multimedia/libtiff/tiff_4.3.0.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://CVE-2026-4775.patch \
+"


### PR DESCRIPTION
Backport patch to fix CVE-2026-4775.

References:
    https://nvd.nist.gov/vuln/detail/CVE-2026-4775
    https://security-tracker.debian.org/tracker/CVE-2026-4775

Upstream fix:
    https://gitlab.com/libtiff/libtiff/-/commit/782a11d6b5b61c6dc21e714950a4af5bf89f023c [debian]