### PR TITLE
core: openssh: fix CVE-2026-35414 & CVE-2026-35414 (Kirkstone)

### DIFF
--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35388.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35388.patch
@@ -1,0 +1,43 @@
+From 2e7011a28c2ad7f1fbb52a96416f772d6033e74f Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:39:57 +0000
+Subject: [PATCH 1/2] upstream: add missing askpass check when using
+
+ControlMaster=ask/autoask and "ssh -O proxy ..."; reported by Michalis
+Vasileiadis
+
+OpenBSD-Commit-ID: 8dd7b9b96534e9a8726916b96d36bed466d3836a
+
+(cherry picked from commit c805b97b67c774e0bf922ffb29dfbcda9d7b5add)
+
+CVE: CVE-2026-35388
+Upstream-Status: Backport [https://anongit.mindrot.org/openssh.git/commit/?id=c805b97b67c774e0bf922ffb29dfbcda9d7b5add]
+Signed-off-by: Colin Pinnell McAllister <colin.mcallister@garmin.com>
+---
+ mux.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/mux.c b/mux.c
+index 176f035c8..41f044a23 100644
+--- a/mux.c
++++ b/mux.c
+@@ -1122,6 +1122,16 @@ mux_master_process_proxy(struct ssh *ssh, u_int rid,
+ 
+ 	debug_f("channel %d: proxy request", c->self);
+ 
++	if (options.control_master == SSHCTL_MASTER_ASK ||
++	    options.control_master == SSHCTL_MASTER_AUTO_ASK) {
++		if (!ask_permission("Allow multiplex proxy connection?")) {
++			debug2_f("proxy refused by user");
++			reply_error(reply, MUX_S_PERMISSION_DENIED, rid,
++			    "Permission denied");
++			return 0;
++		}
++	}
++
+ 	c->mux_rcb = channel_proxy_downstream;
+ 	if ((r = sshbuf_put_u32(reply, MUX_S_PROXY)) != 0 ||
+ 	    (r = sshbuf_put_u32(reply, rid)) != 0)
+-- 
+2.54.0
+

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35414.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35414.patch
@@ -1,0 +1,79 @@
+From 9556493abdbf8c14cb71a91536c0a867b4ea300d Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:48:13 +0000
+Subject: [PATCH 2/2] sshd(8): fix inappropriate matching of authorized_keys
+ principals
+
+When matching an authorized_keys principals="" option against a list of
+principals in a certificate, an incorrect algorithm was used that could
+allow inappropriate matching in cases where a principal name in the
+certificate contains a comma character. Exploitation of the condition
+requires an authorized_keys principals="" option that lists more than
+one principal *and* a CA that will issue a certificate that encodes more
+than one of these principal names separated by a comma (typical CAs
+strongly constrain which principal names they will place in a
+certificate). This condition only applies to user- trusted CA keys in
+authorized_keys, the main certificate authentication path
+(TrustedUserCAKeys/AuthorizedPrincipalsFile) is not affected.
+
+Reported by Vladimir Tokarev.
+
+OpenBSD-Commit-ID: c790e2687c35989ae34a00e709be935c55b16a86
+
+[cjwatson: Committed upstream together with apparently-unrelated changes
+for CVE-2026-35387.  I've split them into separate patches for clarity.]
+
+Origin: backport, https://anongit.mindrot.org/openssh.git/commit/?id=fd1c7e131f331942d20f42f31e79912d570081fa
+Bug-Debian: https://bugs.debian.org/1132576
+Last-Update: 2026-05-11
+
+Patch-Name: CVE-2026-35414.patch
+
+CVE: CVE-2026-35414
+Upstream-Status: Backport [https://salsa.debian.org/ssh-team/openssh/-/commit/ae190b6440b7c599d759527965334eeb49cc75b3]
+Signed-off-by: Colin Pinnell McAllister <colin.mcallister@garmin.com>
+---
+ auth2-pubkey.c | 23 +++++++++++++----------
+ 1 file changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/auth2-pubkey.c b/auth2-pubkey.c
+index 9c2298fc8..2020b23f8 100644
+--- a/auth2-pubkey.c
++++ b/auth2-pubkey.c
+@@ -319,20 +319,23 @@ done:
+ static int
+ match_principals_option(const char *principal_list, struct sshkey_cert *cert)
+ {
+-	char *result;
++	char *list, *olist, *entry;
+ 	u_int i;
+ 
+-	/* XXX percent_expand() sequences for authorized_principals? */
+-
+-	for (i = 0; i < cert->nprincipals; i++) {
+-		if ((result = match_list(cert->principals[i],
+-		    principal_list, NULL)) != NULL) {
+-			debug3("matched principal from key options \"%.100s\"",
+-			    result);
+-			free(result);
+-			return 1;
++	olist = list = xstrdup(principal_list);
++	for (;;) {
++		if ((entry = strsep(&list, ",")) == NULL || *entry == '\0')
++			break;
++		for (i = 0; i < cert->nprincipals; i++) {
++			if (strcmp(entry, cert->principals[i]) == 0) {
++				debug3("matched principal from key i"
++				    "options \"%.100s\"", entry);
++				free(olist);
++				return 1;
++			}
+ 		}
+ 	}
++	free(olist);
+ 	return 0;
+ }
+ 
+-- 
+2.54.0
+

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -8,4 +8,6 @@ SRC_URI:append = " \
     file://CVE-2026-35386-02.patch \
     file://CVE-2026-35386-03.patch \
     file://CVE-2026-60002.patch \
+    file://CVE-2026-35388.patch \
+    file://CVE-2026-35414.patch \
     "


### PR DESCRIPTION
Adds patches for CVE-2026-35414 and CVE-2026-35414.