### PR TITLE
Replace parse check with yocto-check-layer (Kirkstone)

### DIFF
--- a/.github/workflows/bitbake-common.yml
+++ b/.github/workflows/bitbake-common.yml
@@ -21,10 +21,6 @@ on:  # yamllint disable-line rule:truthy
         description: 'If true, bitbake will only build the recipes that are affected by the PR'
         required: true
         type: boolean
-      parse-only:
-        description: 'If true, bitbake only parses and does not build'
-        required: true
-        type: boolean
       runner:
         description: 'The runner to execute this workfow with'
         required: true
@@ -154,12 +150,7 @@ jobs:
           echo "## $AUTO_CONF configuration ##"
           cat "$AUTO_CONF"
 
-          # Run bitbake
-          extra_args=""
-          if [ "${{ inputs.parse-only }}" = "true" ]; then
-            extra_args="--parse-only"
-          fi
-          bitbake $extra_args ${{ inputs.target-image }} ${{ steps.targets.outputs.native_targets }}
+          bitbake ${{ inputs.target-image }} ${{ steps.targets.outputs.native_targets }}
 
       - name: Enable KVM group perms
         if: ${{ inputs.run-tests && steps.targets.outputs.image_targets != '' }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,7 +30,6 @@ jobs:
     with:
       branch: ${{ github.base_ref }}
       only-build-modified: true
-      parse-only: false
       run-tests: true
       runner: yocto_build_host
       use-systemd: ${{ matrix.systemd }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,23 +12,20 @@ jobs:
   lint:
     uses: ./.github/workflows/lint-common.yml
 
-  parse:
-    name: 'Parse recipes'
+  check-layer:
+    name: 'Check meta-lts-collab layer'
     needs: lint
-    uses: ./.github/workflows/bitbake-common.yml
+    uses: ./.github/workflows/yocto-check-layer.yml
     with:
       branch: ${{ github.base_ref }}
-      only-build-modified: false
-      parse-only: true
       runner: ubuntu-22.04
-      use-cache: false
 
   build:
     name: 'Build and test recipes (Systemd: ${{ matrix.systemd }})'
     strategy:
       matrix:
         systemd: [true, false]
-    needs: parse
+    needs: check-layer
     uses: ./.github/workflows/bitbake-common.yml
     with:
       branch: ${{ github.base_ref }}

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -14,21 +14,19 @@ jobs:
   lint:
     uses: ./.github/workflows/lint-common.yml
 
-  parse:
+  check-layer:
+    name: 'Check meta-lts-collab layer'
     needs: lint
-    uses: ./.github/workflows/bitbake-common.yml
+    uses: ./.github/workflows/yocto-check-layer.yml
     with:
-      branch: ${{ github.ref_name }}
-      only-build-modified: false
-      parse-only: true
+      branch: ${{ github.base_ref }}
       runner: ubuntu-22.04
-      use-cache: false
 
   build:
     strategy:
       matrix:
         systemd: [true, false]
-    needs: parse
+    needs: check-layer
     uses: ./.github/workflows/bitbake-common.yml
     with:
       branch: ${{ github.ref_name }}

--- a/.github/workflows/push-periodic.yml
+++ b/.github/workflows/push-periodic.yml
@@ -31,7 +31,6 @@ jobs:
     with:
       branch: ${{ github.ref_name }}
       only-build-modified: false
-      parse-only: false
       run-tests: ${{ github.event_name == 'schedule' }}
       runner: yocto_build_host
       save-cache: true

--- a/.github/workflows/yocto-check-layer.yml
+++ b/.github/workflows/yocto-check-layer.yml
@@ -1,0 +1,65 @@
+name: Yocto Check Layer
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The Yocto branch to run yocto-check-layer against'
+        required: true
+        type: string
+      runner:
+        description: 'The runner to execute this workflow with'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  yocto-check-layer:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Clone meta-lts-collab
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ inputs.branch }}
+          path: ${{ github.workspace }}/meta-lts-collab
+
+      - name: Clone poky (${{ inputs.branch }})
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          repository: yoctoproject/poky
+          ref: ${{ inputs.branch }}
+          path: ${{ github.workspace }}/poky
+
+      - name: Clone meta-oe (${{ inputs.branch }})
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          repository: openembedded/meta-openembedded
+          ref: ${{ inputs.branch }}
+          path: ${{ github.workspace }}/meta-oe
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gawk wget git-core diffstat unzip texinfo gcc-multilib \
+            build-essential chrpath socat cpio python3 python3-pip \
+            python3-pexpect xz-utils debianutils iputils-ping python3-git \
+            python3-jinja2 libegl1-mesa libsdl1.2-dev pylint xterm \
+            python3-subunit mesa-common-dev
+
+      - name: Setup and run yocto-check-layer
+        if: ${{ steps.targets.outputs.all_build_targets != '' }}
+        run: |
+          # Source build environment
+          source poky/oe-init-build-env
+
+          # Add all layers
+          bitbake-layers add-layer $GITHUB_WORKSPACE/meta-oe/meta-*
+          bitbake-layers show-layers
+
+          # Run yocto-check-layer
+          yocto-check-layer \
+            --without-software-layer-signature-check
+            $GITHUB_WORKSPACE/meta-lts-collab


### PR DESCRIPTION
Parsing is one of many tests implemented by the upstream yocto-check-layer tool. This upstream tool should be used instead. This PR replaces the current parse job, that is part of pull-request and push/periodic pipelines, and replaces it with yocto-check-layer.