### PR TITLE
ci: downgrade cve-check runner

### DIFF
--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     with:
       branch: ${{ matrix.branch }}
-      runner: yocto_build_host
+      runner: ubuntu-22.04
 
   deploy:
     needs: cve-check

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -2,7 +2,7 @@ name: CVE Summary Pages
 
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: " 0 3 * * SUN"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Downgrades cve-check runner from the build runners to save compute resources. It's unlikely that the cve_check task is that resource intensive and the long NVD database update times will be the bottleneck regardless of the CPU and memory resources available on the CI node.

Also reduces cve-check from running nightly to running weekly.