### PR TITLE
core: curl: fix backport of CVE-2026-8927 (kirkstone)

### DIFF
--- a/meta-core/recipes-support/curl/files/CVE-2026-8927.patch
+++ b/meta-core/recipes-support/curl/files/CVE-2026-8927.patch
@@ -1,4 +1,4 @@
-From 4ccded03ad219e1fc5c10a748d04fb58a0adb999 Mon Sep 17 00:00:00 2001
+From 1ed847c32773a31ea5750b3de539a8163cb73e4e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jo=C3=A3o=20Marcos=20Costa?= <joaomarcos.costa@bootlin.com>
 Date: Wed, 22 Jul 2026 17:25:35 +0200
 Subject: [PATCH] url: detect proxy changes read from environment
@@ -16,18 +16,21 @@ Closes #21666
 
 Upstream-Status: Backport [https://github.com/curl/curl/commit/5c225384b8d52c6]
 Signed-off-by: João Marcos Costa (Schneider Electric) <joaomarcos.costa@bootlin.com>
+[fixed previous backport, CURL_DISABLE_DIGEST_AUTH is not available at that state
+ and parent needs to freed last (free(data))]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
 ---
  lib/url.c                  |  12 ++++
- lib/urldata.h              |   4 +-
+ lib/urldata.h              |   3 +
  tests/data/test1647        | 103 +++++++++++++++++++++++++++++++
  tests/libtest/Makefile.inc |   4 ++
  tests/libtest/lib1647.c    | 120 +++++++++++++++++++++++++++++++++++++
- 5 files changed, 242 insertions(+), 1 deletion(-)
+ 5 files changed, 242 insertions(+)
  create mode 100644 tests/data/test1647
  create mode 100644 tests/libtest/lib1647.c
 
 diff --git a/lib/url.c b/lib/url.c
-index 0797fb9..09b9923 100644
+index 0797fb9..1998be4 100644
 --- a/lib/url.c
 +++ b/lib/url.c
 @@ -110,6 +110,7 @@ bool curl_win32_idn_to_ascii(const char *in, char **out);
@@ -38,21 +41,21 @@ index 0797fb9..09b9923 100644
  #include "http2.h"
  #include "file.h"
  #include "curl_ldap.h"
-@@ -475,6 +476,9 @@ CURLcode Curl_close(struct Curl_easy **datap)
+@@ -474,6 +475,9 @@ CURLcode Curl_close(struct Curl_easy **datap)
+   /* destruct wildcard structures if it is needed */
    Curl_wildcard_dtor(&data->wildcard);
    Curl_freeset(data);
-   free(data);
-+#ifndef CURL_DISABLE_DIGEST_AUTH
++#ifndef CURL_DISABLE_CRYPTO_AUTH
 +  free(data->state.envproxy);
 +#endif
+   free(data);
    return CURLE_OK;
  }
- 
 @@ -2781,6 +2785,14 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
        result = CURLE_UNSUPPORTED_PROTOCOL;
        goto out;
  #else
-+#ifndef CURL_DISABLE_DIGEST_AUTH
++#ifndef CURL_DISABLE_CRYPTO_AUTH
 +      if(!Curl_safecmp(data->state.envproxy, proxy)) {
 +        /* proxy changed */
 +        Curl_auth_digest_cleanup(&data->state.proxydigest);
@@ -64,22 +67,19 @@ index 0797fb9..09b9923 100644
        if(!(conn->handler->protocol & PROTO_FAMILY_HTTP)) {
          if((conn->handler->flags & PROTOPT_PROXY_AS_HTTP) &&
 diff --git a/lib/urldata.h b/lib/urldata.h
-index d252e73..390ac90 100644
+index d252e73..979d3ad 100644
 --- a/lib/urldata.h
 +++ b/lib/urldata.h
-@@ -1363,9 +1363,11 @@ struct UrlState {
+@@ -1362,6 +1362,9 @@ struct UrlState {
+ #ifdef HAVE_SIGNAL
    /* storage for the previous bag^H^H^HSIGPIPE signal handler :-) */
    void (*prev_signal)(int sig);
- #endif
-+#ifndef CURL_DISABLE_DIGEST_AUTH
++#endif
++#ifndef CURL_DISABLE_CRYPTO_AUTH
 +  char *envproxy; /* last proxy string used for proxy-related state */
+ #endif
    struct digestdata digest;      /* state data for host Digest auth */
    struct digestdata proxydigest; /* state data for proxy Digest auth */
--
-+#endif
-   struct auth authhost;  /* auth details for host */
-   struct auth authproxy; /* auth details for proxy */
- #ifdef USE_CURL_ASYNC
 diff --git a/tests/data/test1647 b/tests/data/test1647
 new file mode 100644
 index 0000000..a87487f


### PR DESCRIPTION
The backport as is leads to a crash in Curl_close. The backport of CVE-2026-8927 had following issues:
- free(data->state.envproxy) was called after parent free(data)
- the CURL_DISABLE_DIGEST_AUTH is not yet available in curl 7.82 used CURL_DISABLE_CRYPTO_AUTH instead which is also used for Curl_auth_digest_cleanup()