### PR TITLE
curl: fix CVE-2026-5773, CVE-2026-7168

### DIFF
--- a/meta-core/recipes-support/curl/curl_7.82.0.bbappend
+++ b/meta-core/recipes-support/curl/curl_7.82.0.bbappend
@@ -2,4 +2,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "\
     file://CVE-2026-8927.patch \
+    file://CVE-2026-5773.patch \
+    file://CVE-2026-7168.patch \
 "

--- a/meta-core/recipes-support/curl/files/CVE-2026-5773.patch
+++ b/meta-core/recipes-support/curl/files/CVE-2026-5773.patch
@@ -1,0 +1,57 @@
+From da2e381ba4223883c4171eacc32b4368aea8f0b7 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Sun, 5 Apr 2026 18:23:35 +0200
+Subject: [PATCH] protocol: disable connection reuse for SMB(S)
+
+Connections should only be reused when using the same "share" (and
+perhaps some additional conditions), but instead of fixing this flaw,
+this change completely disables connection reuse for SMB. This protocol
+is about to get dropped soon anyway.
+
+Reported-by: Osama Hamad
+Closes #21238
+
+Backported-by: Samuel Henrique <samueloph@debian.org>
+ * Upstream removes PROTOPT_CONN_REUSE from the SMB and SMBS scheme
+   registrations in lib/protocol.c. That flag (and the lib/protocol.c scheme
+   registry itself) only exists from upstream commit
+   feea96851230c7a5a11feaffa0a5e4a4d30e5e63 ("conncontrol: reuse handling", Nov
+   2025) onward, so neither is present in 8.14.1. In 8.14.1 SMB connection
+   reuse is instead controlled at runtime via connkeep() / connclose(), and
+   lib/smb.c explicitly calls connkeep() in smb_connect() to mark SMB
+   connections as eligible for reuse. Replace that connkeep() with a
+   connclose() so SMB connections are marked as not-reusable, achieving the
+   same effect as the upstream change.
+
+Backported by: Samuel Henrique <samueloph@debian.org>
+ * Bookworm 7.88.1: same connkeep() call in smb_connect() at line
+   271. Apply the same connkeep() -> connclose() swap; this version
+   also lacks PROTOPT_CONN_REUSE so the runtime approach is the
+   only way to express "do not reuse this connection".
+
+Origin: vendor, https://salsa.debian.org/debian/curl/-/raw/debian/bookworm/debian/patches/CVE-2026-5773.patch
+
+CVE: CVE-2026-5773
+Upstream-Status: Backport [https://github.com/curl/curl/commit/74a169575d6412dc0ff532acdf94de35a6c2a571]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ lib/smb.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/lib/smb.c b/lib/smb.c
+index e921ab502..ee8dd0148 100644
+--- a/lib/smb.c
++++ b/lib/smb.c
+@@ -269,8 +269,10 @@ static CURLcode smb_connect(struct Curl_easy *data, bool *done)
+   if(!smbc->recv_buf)
+     return CURLE_OUT_OF_MEMORY;
+ 
+-  /* Multiple requests are allowed with this connection */
+-  connkeep(conn, "SMB default");
++  /* SMB does not allow connection reuse: connections should only be reused
++     when using the same "share" (and possibly other conditions), but rather
++     than implementing that, mark every SMB connection as not reusable. */
++  connclose(conn, "SMB does not allow connection reuse");
+ 
+   /* Parse the username, domain, and password */
+   slash = strchr(conn->user, '/');

--- a/meta-core/recipes-support/curl/files/CVE-2026-7168.patch
+++ b/meta-core/recipes-support/curl/files/CVE-2026-7168.patch
@@ -1,0 +1,122 @@
+From 558daab5aff1320f496d5686ba800f27581ad96c Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 27 Apr 2026 09:14:51 +0200
+Subject: [PATCH] setopt: clear proxy auth properties when switching
+
+Verify with test 1588
+
+Closes #21453
+
+Backported-by: Samuel Henrique <samueloph@debian.org>
+ * lib/setopt.c: upstream's CURLOPT_PROXY case lives in a dedicated
+   setopt_cptr_proxy() function; in 8.14.1 it is still inline in the
+   setopt_cptr() switch. The setproxy() helper is added directly
+   above setopt_cptr() and the inline Curl_setstropt() call is
+   swapped for setproxy().
+ * lib/vauth/vauth.h: upstream's hunk also adds a no-op
+   Curl_auth_is_digest_supported() macro to the CURL_DISABLE_DIGEST_AUTH
+   branch, but our 8.14.1 vauth.h has no such #else branch (the file
+   ends the digest block with a bare #endif). Add only the
+   Curl_auth_digest_cleanup(x) no-op macro inside a new #else, which
+   is the part actually needed by setproxy() in disable-digest builds.
+ * tests/data/test1588: regression test from upstream with two changes:
+   crlf="headers" -> crlf="yes" so the 8.14.1 test runner correctly
+   applies CRLF to header lines on both the server-side data and the
+   expected protocol block; and the "digest" entry in <features> is
+   dropped because the 8.14.1 curlinfo emits the feature toggle as
+   "digest-auth" rather than "digest", so the unmodified feature gate
+   would always SKIP the test on this branch. Other digest-auth tests
+   (e.g. test1061) similarly do not list "digest" as a required
+   feature.
+ * tests/libtest/lib1588.c: rewritten to use the 8.14.1 libtest
+   harness (test.h / CURLcode test(char *URL) / easy_init / easy_setopt
+   with goto test_cleanup) instead of upstream's newer first.h-based
+   one. The init1588() helper also reuses the parent's test_cleanup
+   label rather than upstream's separate init_failed label, since
+   8.14.1's easy_setopt jumps directly to test_cleanup.
+
+Backported by: Samuel Henrique <samueloph@debian.org>
+ * Bookworm 7.88.1: lib/setopt.c is a single Curl_vsetopt() function
+   with one big switch (no setopt_cptr() sub-switch like trixie).
+   Add the setproxy() helper just above Curl_vsetopt() instead, and
+   replace the inline Curl_setstropt() in the CURLOPT_PROXY case
+   with `result = setproxy(data, va_arg(param, char *));`.
+ * lib/vauth/vauth.h: bookworm uses CURL_DISABLE_CRYPTO_AUTH (the
+   pre-split spelling) instead of CURL_DISABLE_DIGEST_AUTH. Add the
+   no-op Curl_auth_digest_cleanup(x) macro under the matching
+   #else branch.
+ * Drop the test additions: bookworm has neither the test1588
+   xml-test infrastructure for CONNECT-based digest replay nor the
+   modern libtest harness (test.h / CURLcode test(char *URL)) the
+   trixie adaptation rewrote against -- backporting the test would
+   require touching the test runner setup more aggressively than is
+   appropriate for a stable update. The security property (proxy
+   auth state cleared on CURLOPT_PROXY change) is the setproxy()
+   helper itself.
+
+Origin: vendor, https://salsa.debian.org/debian/curl/-/raw/debian/bookworm/debian/patches/CVE-2026-7168.patch
+
+CVE: CVE-2026-7168
+Upstream-Status: Backport [https://github.com/curl/curl/commit/c1cfdf59acbaf9504c4578d4cf56cdd7c8594507]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ lib/setopt.c      | 18 ++++++++++++++++--
+ lib/vauth/vauth.h |  2 ++
+ 2 files changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/lib/setopt.c b/lib/setopt.c
+index b63ffdf48..920ac4235 100644
+--- a/lib/setopt.c
++++ b/lib/setopt.c
+@@ -48,6 +48,7 @@
+ #include "multiif.h"
+ #include "altsvc.h"
+ #include "hsts.h"
++#include "vauth/vauth.h"
+ 
+ /* The last 3 #include files should be in this order */
+ #include "curl_printf.h"
+@@ -146,6 +147,20 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
+ #define C_SSLVERSION_VALUE(x) (x & 0xffff)
+ #define C_SSLVERSION_MAX_VALUE(x) (x & 0xffff0000)
+ 
++#ifndef CURL_DISABLE_PROXY
++static CURLcode setproxy(struct Curl_easy *data, const char *proxy)
++{
++  if((data->set.str[STRING_PROXY] && proxy) &&
++     /* there was one set, is this a new one? */
++     !strcmp(data->set.str[STRING_PROXY], proxy))
++    return CURLE_OK; /* same one as before */
++
++  Curl_auth_digest_cleanup(&data->state.proxydigest);
++  memset(&data->state.authproxy, 0, sizeof(data->state.authproxy));
++  return Curl_setstropt(&data->set.str[STRING_PROXY], proxy);
++}
++#endif
++
+ /*
+  * Do not make Curl_vsetopt() static: it is called from
+  * packages/OS400/ccsidcurl.c.
+@@ -1072,8 +1087,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+      * Setting it to NULL, means no proxy but allows the environment variables
+      * to decide for us (if CURLOPT_SOCKS_PROXY setting it to NULL).
+      */
+-    result = Curl_setstropt(&data->set.str[STRING_PROXY],
+-                            va_arg(param, char *));
++    result = setproxy(data, va_arg(param, char *));
+     break;
+ 
+   case CURLOPT_PRE_PROXY:
+diff --git a/lib/vauth/vauth.h b/lib/vauth/vauth.h
+index 6e1237834..709c3a52c 100644
+--- a/lib/vauth/vauth.h
++++ b/lib/vauth/vauth.h
+@@ -111,6 +111,8 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
+ 
+ /* This is used to clean up the digest specific data */
+ void Curl_auth_digest_cleanup(struct digestdata *digest);
++#else
++#define Curl_auth_digest_cleanup(x)
+ #endif /* !CURL_DISABLE_CRYPTO_AUTH */
+ 
+ #ifdef USE_GSASL


### PR DESCRIPTION
Backport debian backported patches for CVE-2026-5773 and CVE-2026-7168