### PR TITLE
curl: CVE-2026-8927.patch: add missing CVE tag

### DIFF
--- a/meta-core/recipes-support/curl/files/CVE-2026-8927.patch
+++ b/meta-core/recipes-support/curl/files/CVE-2026-8927.patch
@@ -14,6 +14,7 @@ sure Digest state is flushed in the second use
 
 Closes #21666
 
+CVE: CVE-2026-8927
 Upstream-Status: Backport [https://github.com/curl/curl/commit/5c225384b8d52c6]
 Signed-off-by: João Marcos Costa (Schneider Electric) <joaomarcos.costa@bootlin.com>
 [fixed previous backport, CURL_DISABLE_DIGEST_AUTH is not available at that state


### PR DESCRIPTION
The patch file lacks the ID of the CVE it fixes.

While in kirkstone the CVE ID can be inferred [1] from the patch name, add the tag anyway to make it coherent with the other patches in this layer.

[1] https://git.openembedded.org/openembedded-core/tree/meta/lib/oe/cve_check.py?h=kirkstone#n92