### PR TITLE
curl: backports CVE patches from kirkstone (dunfell)

### DIFF
--- a/meta-core/recipes-support/curl/curl/CVE-2026-1965-1.patch
+++ b/meta-core/recipes-support/curl/curl/CVE-2026-1965-1.patch
@@ -1,0 +1,106 @@
+From 3707e0706a1c47a30f7b32903359e92fd3712f26 Mon Sep 17 00:00:00 2001
+From: Andrej Koehler <akhldev@proton.me>
+Date: Tue, 4 Aug 2026 14:40:09 +0200
+Subject: [PATCH] url: fix reuse of connections using HTTP Negotiate
+
+Assume Negotiate means connection-based
+
+Reported-by: Zhicheng Chen
+Closes #20534
+
+Upstream-Status: Backport [https://github.com/curl/curl/commit/34fa034d9a390c4bd6]
+Backported by Ubuntu team https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/curl/7.81.0-1ubuntu1.23/curl_7.81.0-1ubuntu1.23.debian.tar.xz
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-support/curl/curl/CVE-2026-1965-1.patch?h=kirkstone
+
+CVE: CVE-2026-1965
+Signed-off-by: Vijay Anusuri <vanusuri@mvista.com>
+[minor fix of origin patch: aligned the compile define condition of the
+variable declaration with the usage]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ lib/url.c | 64 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 64 insertions(+)
+
+diff --git a/lib/url.c b/lib/url.c
+index b0cb9dc52..ddc50c4d1 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -1059,6 +1059,18 @@ ConnectionExists(struct Curl_easy *data,
+                            (needle->handler->protocol & PROTO_FAMILY_HTTP)));
+ #endif
+ 
++#if !defined(CURL_DISABLE_HTTP) && defined(USE_SPNEGO)
++  bool wantNegohttp =
++    (data->state.authhost.want & CURLAUTH_NEGOTIATE) &&
++    (needle->handler->protocol & PROTO_FAMILY_HTTP);
++#ifndef CURL_DISABLE_PROXY
++  bool wantProxyNegohttp =
++    needle->bits.proxy_user_passwd &&
++    (data->state.authproxy.want & CURLAUTH_NEGOTIATE) &&
++    (needle->handler->protocol & PROTO_FAMILY_HTTP);
++#endif
++#endif
++
+   *force_reuse = FALSE;
+   *waitpipe = FALSE;
+ 
+@@ -1386,6 +1398,58 @@ ConnectionExists(struct Curl_easy *data,
+           continue;
+         }
+ #endif
++
++#if !defined(CURL_DISABLE_HTTP) && defined(USE_SPNEGO)
++        /* If we are looking for an HTTP+Negotiate connection, check if this
++           is already authenticating with the right credentials. If not, keep
++           looking so that we can reuse Negotiate connections if possible. */
++        if(wantNegohttp) {
++          if(Curl_timestrcmp(needle->user, check->user) ||
++             Curl_timestrcmp(needle->passwd, check->passwd))
++            continue;
++        }
++        else if(check->http_negotiate_state != GSS_AUTHNONE) {
++          /* Connection is using Negotiate auth but we do not want Negotiate */
++          continue;
++        }
++
++#ifndef CURL_DISABLE_PROXY
++        /* Same for Proxy Negotiate authentication */
++        if(wantProxyNegohttp) {
++          /* Both check->http_proxy.user and check->http_proxy.passwd can be
++           * NULL */
++          if(!check->http_proxy.user || !check->http_proxy.passwd)
++            continue;
++
++          if(Curl_timestrcmp(needle->http_proxy.user,
++                             check->http_proxy.user) ||
++             Curl_timestrcmp(needle->http_proxy.passwd,
++                             check->http_proxy.passwd))
++            continue;
++        }
++        else if(check->proxy_negotiate_state != GSS_AUTHNONE) {
++          /* Proxy connection is using Negotiate auth but we do not want
++           * Negotiate */
++          continue;
++        }
++#endif
++        if(wantNTLMhttp || wantProxyNTLMhttp) {
++          /* Credentials are already checked, we may use this connection. We
++           * MUST use a connection where it has already been fully negotiated.
++           * If it has not, we keep on looking for a better one. */
++          chosen = check;
++          if((wantNegohttp &&
++              (check->http_negotiate_state != GSS_AUTHNONE)) ||
++             (wantProxyNegohttp &&
++              (check->proxy_negotiate_state != GSS_AUTHNONE))) {
++            /* We must use this connection, no other */
++            *force_reuse = TRUE;
++            break;
++          }
++          continue; /* get another */
++        }
++#endif
++
+         if(canmultiplex) {
+           /* We can multiplex if we want to. Let's continue looking for
+              the optimal connection to use. */

--- a/meta-core/recipes-support/curl/curl/CVE-2026-1965-2.patch
+++ b/meta-core/recipes-support/curl/curl/CVE-2026-1965-2.patch
@@ -1,0 +1,34 @@
+From d1efcf087711f3126e2e36687c72d93a3a697e12 Mon Sep 17 00:00:00 2001
+From: Andrej Koehler <akhldev@proton.me>
+Date: Tue, 4 Aug 2026 14:52:03 +0200
+Subject: [PATCH] url: fix copy and paste url_match_auth_nego mistake
+
+Follow-up to 34fa034
+Reported-by: dahmono on github
+Closes #20662
+
+Upstream-Status: Backport [https://github.com/curl/curl/commit/f1a39f221d57354990]
+Backported by Ubuntu team https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/curl/7.81.0-1ubuntu1.23/curl_7.81.0-1ubuntu1.23.debian.tar.xz
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-support/curl/curl/CVE-2026-1965-2.patch?h=kirkstone
+
+CVE: CVE-2026-1965
+Signed-off-by: Vijay Anusuri <vanusuri@mvista.com>
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ lib/url.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/url.c b/lib/url.c
+index ddc50c4d1..b2254eab0 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -1433,7 +1433,7 @@ ConnectionExists(struct Curl_easy *data,
+           continue;
+         }
+ #endif
+-        if(wantNTLMhttp || wantProxyNTLMhttp) {
++        if(wantNegohttp || wantProxyNegohttp) {
+           /* Credentials are already checked, we may use this connection. We
+            * MUST use a connection where it has already been fully negotiated.
+            * If it has not, we keep on looking for a better one. */

--- a/meta-core/recipes-support/curl/curl/CVE-2026-3783-pre1.patch
+++ b/meta-core/recipes-support/curl/curl/CVE-2026-3783-pre1.patch
@@ -1,0 +1,69 @@
+From dd739ca2bccd7f1ec0ca0d56ca8bc747873588de Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Fri, 29 Apr 2022 22:56:47 +0200
+Subject: [PATCH] http: move Curl_allow_auth_to_host()
+
+It was mistakenly put within the CURL_DISABLE_HTTP_AUTH #ifdef
+
+Reported-by: Michael Olbrich
+Fixes #8772
+Closes #8775
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-support/curl/curl/CVE-2026-3783-pre1.patch?h=kirkstone
+
+Upstream-Status: Backport [https://github.com/curl/curl/commit/d7b970e46ba29a7e558e21d19f485977ffed6266]
+CVE: CVE-2026-3783 #Dependency Patch
+Signed-off-by: Vijay Anusuri <vanusuri@mvista.com>
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ lib/http.c | 30 +++++++++++++++---------------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/lib/http.c b/lib/http.c
+index da7209d9a..fba4d0b3d 100644
+--- a/lib/http.c
++++ b/lib/http.c
+@@ -627,6 +627,21 @@ CURLcode Curl_http_auth_act(struct connectdata *conn)
+   return result;
+ }
+ 
++/*
++ * Curl_allow_auth_to_host() tells if authentication, cookies or other
++ * "sensitive data" can (still) be sent to this host.
++ */
++bool Curl_allow_auth_to_host(struct Curl_easy *data)
++{
++  struct connectdata *conn = data->conn;
++  return (!data->state.this_is_a_follow ||
++          data->set.allow_auth_to_other_hosts ||
++          (data->state.first_host &&
++           strcasecompare(data->state.first_host, conn->host.name) &&
++           (data->state.first_remote_port == conn->remote_port) &&
++           (data->state.first_remote_protocol == conn->handler->protocol)));
++}
++
+ #ifndef CURL_DISABLE_HTTP_AUTH
+ /*
+  * Output the correct authentication header depending on the auth type
+@@ -731,21 +746,6 @@ output_auth_headers(struct connectdata *conn,
+   return CURLE_OK;
+ }
+ 
+-/*
+- * Curl_allow_auth_to_host() tells if authentication, cookies or other
+- * "sensitive data" can (still) be sent to this host.
+- */
+-bool Curl_allow_auth_to_host(struct Curl_easy *data)
+-{
+-  struct connectdata *conn = data->conn;
+-  return (!data->state.this_is_a_follow ||
+-          data->set.allow_auth_to_other_hosts ||
+-          (data->state.first_host &&
+-           strcasecompare(data->state.first_host, conn->host.name) &&
+-           (data->state.first_remote_port == conn->remote_port) &&
+-           (data->state.first_remote_protocol == conn->handler->protocol)));
+-}
+-
+ /**
+  * Curl_http_output_auth() setups the authentication headers for the
+  * host/proxy and the correct authentication

--- a/meta-core/recipes-support/curl/curl/CVE-2026-3783.patch
+++ b/meta-core/recipes-support/curl/curl/CVE-2026-3783.patch
@@ -1,0 +1,38 @@
+From 0ddab145ed67b6d4d8c0f4decd4e569c408f543c Mon Sep 17 00:00:00 2001
+From: Andrej Koehler <akhldev@proton.me>
+Date: Wed, 5 Aug 2026 12:38:13 +0200
+Subject: [PATCH] http: only send bearer if auth is allowed
+
+Verify with test 2006
+
+Closes #20843
+
+Curl_auth_allowed_to_host() function got renamed from
+Curl_allow_auth_to_host() by the commit
+https://github.com/curl/curl/commit/72652c0613d37ce18e99cca17a42887f12ad43da
+
+Current curl version 7.82.0 has function Curl_allow_auth_to_host()
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-support/curl/curl/CVE-2026-3783.patch?h=kirkstone
+
+Upstream-Status: Backport [https://github.com/curl/curl/commit/e3d7401a32a46516c9e5ee877]
+CVE: CVE-2026-3783
+Signed-off-by: Vijay Anusuri <vanusuri@mvista.com>
+[dropped test changes, they are not compatible with current curl version]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ lib/http.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/http.c b/lib/http.c
+index fba4d0b3d..ce942897b 100644
+--- a/lib/http.c
++++ b/lib/http.c
+@@ -721,6 +721,7 @@ output_auth_headers(struct connectdata *conn,
+   if(authstatus->picked == CURLAUTH_BEARER) {
+     /* Bearer */
+     if((!proxy && data->set.str[STRING_BEARER] &&
++        Curl_allow_auth_to_host(data) &&
+         !Curl_checkheaders(conn, "Authorization:"))) {
+       auth = "Bearer";
+       result = http_output_bearer(conn);

--- a/meta-core/recipes-support/curl/curl/CVE-2026-3784.patch
+++ b/meta-core/recipes-support/curl/curl/CVE-2026-3784.patch
@@ -1,0 +1,76 @@
+From 63b4cb732f3e73e5b9312644cdffd3ada6f4a48b Mon Sep 17 00:00:00 2001
+From: Andrej Koehler <akhldev@proton.me>
+Date: Wed, 5 Aug 2026 13:01:31 +0200
+Subject: [PATCH] proxy-auth: additional tests
+
+Also eliminate the special handling for socks proxy match.
+
+Closes #20837
+
+Upstream-Status: Backport [https://github.com/curl/curl/commit/5f13a7645e565c5c1a06f3]
+Backported by Ubuntu team https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/curl/7.81.0-1ubuntu1.23/curl_7.81.0-1ubuntu1.23.debian.tar.xz
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-support/curl/curl/CVE-2026-3784.patch?h=kirkstone
+
+CVE: CVE-2026-3784
+Signed-off-by: Vijay Anusuri <vanusuri@mvista.com>
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ lib/url.c | 31 ++++++++-----------------------
+ 1 file changed, 8 insertions(+), 23 deletions(-)
+
+diff --git a/lib/url.c b/lib/url.c
+index b2254eab0..176c30247 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -870,33 +870,18 @@ proxy_info_matches(const struct proxy_info* data,
+ {
+   if((data->proxytype == needle->proxytype) &&
+      (data->port == needle->port) &&
+-     Curl_safe_strcasecompare(data->host.name, needle->host.name))
+-    return TRUE;
++     curl_strequal(data->host.name, needle->host.name)) {
+ 
++    if(Curl_timestrcmp(data->user, needle->user) ||
++       Curl_timestrcmp(data->passwd, needle->passwd))
++      return FALSE;
++    return TRUE;
++  }
+   return FALSE;
+ }
+-
+-static bool
+-socks_proxy_info_matches(const struct proxy_info* data,
+-                         const struct proxy_info* needle)
+-{
+-  if(!proxy_info_matches(data, needle))
+-    return FALSE;
+-
+-  /* the user information is case-sensitive
+-     or at least it is not defined as case-insensitive
+-     see https://tools.ietf.org/html/rfc3986#section-3.2.1 */
+-
+-  /* curl_strequal does a case insentive comparison, so do not use it here! */
+-  if(Curl_timestrcmp(data->user, needle->user) ||
+-     Curl_timestrcmp(data->passwd, needle->passwd))
+-    return FALSE;
+-  return TRUE;
+-}
+ #else
+ /* disabled, won't get called */
+ #define proxy_info_matches(x,y) FALSE
+-#define socks_proxy_info_matches(x,y) FALSE
+ #endif
+ 
+ /* A connection has to have been idle for a shorter time than 'maxage_conn' to
+@@ -1185,8 +1170,8 @@ ConnectionExists(struct Curl_easy *data,
+         continue;
+ 
+       if(needle->bits.socksproxy &&
+-        !socks_proxy_info_matches(&needle->socks_proxy,
+-                                  &check->socks_proxy))
++        !proxy_info_matches(&needle->socks_proxy,
++                            &check->socks_proxy))
+         continue;
+ 
+       if(needle->bits.conn_to_host != check->bits.conn_to_host)

--- a/meta-core/recipes-support/curl/curl/CVE-2026-5773.patch
+++ b/meta-core/recipes-support/curl/curl/CVE-2026-5773.patch
@@ -1,0 +1,57 @@
+From 55f9e6df4c21bc3bb32eb6ec43d55e4d2c349a1b Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Sun, 5 Apr 2026 18:23:35 +0200
+Subject: [PATCH] protocol: disable connection reuse for SMB(S)
+
+Connections should only be reused when using the same "share" (and
+perhaps some additional conditions), but instead of fixing this flaw,
+this change completely disables connection reuse for SMB. This protocol
+is about to get dropped soon anyway.
+
+Reported-by: Osama Hamad
+Closes #21238
+
+Backported-by: Samuel Henrique <samueloph@debian.org>
+ * Upstream removes PROTOPT_CONN_REUSE from the SMB and SMBS scheme
+   registrations in lib/protocol.c. That flag (and the lib/protocol.c scheme
+   registry itself) only exists from upstream commit
+   feea96851230c7a5a11feaffa0a5e4a4d30e5e63 ("conncontrol: reuse handling", Nov
+   2025) onward, so neither is present in 8.14.1. In 8.14.1 SMB connection
+   reuse is instead controlled at runtime via connkeep() / connclose(), and
+   lib/smb.c explicitly calls connkeep() in smb_connect() to mark SMB
+   connections as eligible for reuse. Replace that connkeep() with a
+   connclose() so SMB connections are marked as not-reusable, achieving the
+   same effect as the upstream change.
+
+Backported by: Samuel Henrique <samueloph@debian.org>
+ * Bookworm 7.88.1: same connkeep() call in smb_connect() at line
+   271. Apply the same connkeep() -> connclose() swap; this version
+   also lacks PROTOPT_CONN_REUSE so the runtime approach is the
+   only way to express "do not reuse this connection".
+
+Origin: other, https://raw.githubusercontent.com/garmin/meta-lts-collab/refs/heads/kirkstone/meta-core/recipes-support/curl/files/CVE-2026-5773.patch
+
+CVE: CVE-2026-5773
+Upstream-Status: Backport [https://github.com/curl/curl/commit/74a169575d6412dc0ff532acdf94de35a6c2a571]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ lib/smb.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/lib/smb.c b/lib/smb.c
+index ffce1cc84..30746d22e 100644
+--- a/lib/smb.c
++++ b/lib/smb.c
+@@ -257,8 +257,10 @@ static CURLcode smb_connect(struct connectdata *conn, bool *done)
+   if(!smbc->recv_buf)
+     return CURLE_OUT_OF_MEMORY;
+ 
+-  /* Multiple requests are allowed with this connection */
+-  connkeep(conn, "SMB default");
++  /* SMB does not allow connection reuse: connections should only be reused
++     when using the same "share" (and possibly other conditions), but rather
++     than implementing that, mark every SMB connection as not reusable. */
++  connclose(conn, "SMB does not allow connection reuse");
+ 
+   /* Parse the username, domain, and password */
+   slash = strchr(conn->user, '/');

--- a/meta-core/recipes-support/curl/curl/CVE-2026-7168.patch
+++ b/meta-core/recipes-support/curl/curl/CVE-2026-7168.patch
@@ -1,0 +1,122 @@
+From 76e84f2daeff466763b11c9c7e2dd2c1a7509a6c Mon Sep 17 00:00:00 2001
+From: Andrej Koehler <akhldev@proton.me>
+Date: Wed, 5 Aug 2026 13:28:56 +0200
+Subject: [PATCH] setopt: clear proxy auth properties when switching
+
+Verify with test 1588
+
+Closes #21453
+
+Backported-by: Samuel Henrique <samueloph@debian.org>
+ * lib/setopt.c: upstream's CURLOPT_PROXY case lives in a dedicated
+   setopt_cptr_proxy() function; in 8.14.1 it is still inline in the
+   setopt_cptr() switch. The setproxy() helper is added directly
+   above setopt_cptr() and the inline Curl_setstropt() call is
+   swapped for setproxy().
+ * lib/vauth/vauth.h: upstream's hunk also adds a no-op
+   Curl_auth_is_digest_supported() macro to the CURL_DISABLE_DIGEST_AUTH
+   branch, but our 8.14.1 vauth.h has no such #else branch (the file
+   ends the digest block with a bare #endif). Add only the
+   Curl_auth_digest_cleanup(x) no-op macro inside a new #else, which
+   is the part actually needed by setproxy() in disable-digest builds.
+ * tests/data/test1588: regression test from upstream with two changes:
+   crlf="headers" -> crlf="yes" so the 8.14.1 test runner correctly
+   applies CRLF to header lines on both the server-side data and the
+   expected protocol block; and the "digest" entry in <features> is
+   dropped because the 8.14.1 curlinfo emits the feature toggle as
+   "digest-auth" rather than "digest", so the unmodified feature gate
+   would always SKIP the test on this branch. Other digest-auth tests
+   (e.g. test1061) similarly do not list "digest" as a required
+   feature.
+ * tests/libtest/lib1588.c: rewritten to use the 8.14.1 libtest
+   harness (test.h / CURLcode test(char *URL) / easy_init / easy_setopt
+   with goto test_cleanup) instead of upstream's newer first.h-based
+   one. The init1588() helper also reuses the parent's test_cleanup
+   label rather than upstream's separate init_failed label, since
+   8.14.1's easy_setopt jumps directly to test_cleanup.
+
+Backported by: Samuel Henrique <samueloph@debian.org>
+ * Bookworm 7.88.1: lib/setopt.c is a single Curl_vsetopt() function
+   with one big switch (no setopt_cptr() sub-switch like trixie).
+   Add the setproxy() helper just above Curl_vsetopt() instead, and
+   replace the inline Curl_setstropt() in the CURLOPT_PROXY case
+   with `result = setproxy(data, va_arg(param, char *));`.
+ * lib/vauth/vauth.h: bookworm uses CURL_DISABLE_CRYPTO_AUTH (the
+   pre-split spelling) instead of CURL_DISABLE_DIGEST_AUTH. Add the
+   no-op Curl_auth_digest_cleanup(x) macro under the matching
+   #else branch.
+ * Drop the test additions: bookworm has neither the test1588
+   xml-test infrastructure for CONNECT-based digest replay nor the
+   modern libtest harness (test.h / CURLcode test(char *URL)) the
+   trixie adaptation rewrote against -- backporting the test would
+   require touching the test runner setup more aggressively than is
+   appropriate for a stable update. The security property (proxy
+   auth state cleared on CURLOPT_PROXY change) is the setproxy()
+   helper itself.
+
+Origin: other, https://raw.githubusercontent.com/garmin/meta-lts-collab/refs/heads/kirkstone/meta-core/recipes-support/curl/files/CVE-2026-7168.patch
+
+CVE: CVE-2026-7168
+Upstream-Status: Backport [https://github.com/curl/curl/commit/c1cfdf59acbaf9504c4578d4cf56cdd7c8594507]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ lib/setopt.c      | 18 ++++++++++++++++--
+ lib/vauth/vauth.h |  2 ++
+ 2 files changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/lib/setopt.c b/lib/setopt.c
+index 37b758dd7..14260809e 100644
+--- a/lib/setopt.c
++++ b/lib/setopt.c
+@@ -45,6 +45,7 @@
+ #include "setopt.h"
+ #include "multiif.h"
+ #include "altsvc.h"
++#include "vauth/vauth.h"
+ 
+ /* The last 3 #include files should be in this order */
+ #include "curl_printf.h"
+@@ -119,6 +120,20 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
+ #define C_SSLVERSION_VALUE(x) (x & 0xffff)
+ #define C_SSLVERSION_MAX_VALUE(x) (x & 0xffff0000)
+ 
++#ifndef CURL_DISABLE_PROXY
++static CURLcode setproxy(struct Curl_easy *data, const char *proxy)
++{
++  if((data->set.str[STRING_PROXY] && proxy) &&
++     /* there was one set, is this a new one? */
++     !strcmp(data->set.str[STRING_PROXY], proxy))
++    return CURLE_OK; /* same one as before */
++
++  Curl_auth_digest_cleanup(&data->state.proxydigest);
++  memset(&data->state.authproxy, 0, sizeof(data->state.authproxy));
++  return Curl_setstropt(&data->set.str[STRING_PROXY], proxy);
++}
++#endif
++
+ /*
+  * Do not make Curl_vsetopt() static: it is called from
+  * packages/OS400/ccsidcurl.c.
+@@ -990,8 +1005,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+      * Setting it to NULL, means no proxy but allows the environment variables
+      * to decide for us (if CURLOPT_SOCKS_PROXY setting it to NULL).
+      */
+-    result = Curl_setstropt(&data->set.str[STRING_PROXY],
+-                            va_arg(param, char *));
++    result = setproxy(data, va_arg(param, char *));
+     break;
+ 
+   case CURLOPT_PRE_PROXY:
+diff --git a/lib/vauth/vauth.h b/lib/vauth/vauth.h
+index a1a557d2a..44a2c5c44 100644
+--- a/lib/vauth/vauth.h
++++ b/lib/vauth/vauth.h
+@@ -113,6 +113,8 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
+ 
+ /* This is used to clean up the digest specific data */
+ void Curl_auth_digest_cleanup(struct digestdata *digest);
++#else
++#define Curl_auth_digest_cleanup(x)
+ #endif /* !CURL_DISABLE_CRYPTO_AUTH */
+ 
+ #if defined(USE_NTLM)

--- a/meta-core/recipes-support/curl/curl/CVE-2026-8927.patch
+++ b/meta-core/recipes-support/curl/curl/CVE-2026-8927.patch
@@ -1,0 +1,80 @@
+From 9bd09814501a776a24182acef52b358c76d9372c Mon Sep 17 00:00:00 2001
+From: Andrej Koehler <akhldev@proton.me>
+Date: Wed, 5 Aug 2026 13:15:51 +0200
+Subject: [PATCH] url: detect proxy changes read from environment MIME-Version:
+ 1.0 Content-Type: text/plain; charset=UTF-8 Content-Transfer-Encoding: 8bit
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When a proxy is set from an environment variable, detect if that proxy
+is not the same as previously and flush state.
+
+Verified by test1647: verify changing proxy with env variables and make
+sure Digest state is flushed in the second use
+
+Closes #21666
+
+Origin: other, https://raw.githubusercontent.com/garmin/meta-lts-collab/refs/heads/kirkstone/meta-core/recipes-support/curl/files/CVE-2026-8927.patch
+
+CVE: CVE-2026-8927
+Upstream-Status: Backport [https://github.com/curl/curl/commit/5c225384b8d52c6]
+Signed-off-by: João Marcos Costa (Schneider Electric) <joaomarcos.costa@bootlin.com>
+[dropped test changes, they are not compatible with current curl version]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ lib/url.c     | 12 ++++++++++++
+ lib/urldata.h |  3 +++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/lib/url.c b/lib/url.c
+index 176c30247..66fff8863 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -103,6 +103,7 @@ bool curl_win32_idn_to_ascii(const char *in, char **out);
+ #include "telnet.h"
+ #include "tftp.h"
+ #include "http.h"
++#include "vauth/vauth.h"
+ #include "http2.h"
+ #include "file.h"
+ #include "curl_ldap.h"
+@@ -411,6 +412,9 @@ CURLcode Curl_close(struct Curl_easy **datap)
+   /* destruct wildcard structures if it is needed */
+   Curl_wildcard_dtor(&data->wildcard);
+   Curl_freeset(data);
++#ifndef CURL_DISABLE_CRYPTO_AUTH
++  free(data->state.envproxy);
++#endif
+   free(data);
+   return CURLE_OK;
+ }
+@@ -2562,6 +2566,14 @@ static CURLcode create_conn_helper_init_proxy(struct connectdata *conn)
+       result = CURLE_UNSUPPORTED_PROTOCOL;
+       goto out;
+ #else
++#ifndef CURL_DISABLE_CRYPTO_AUTH
++      if(!Curl_safecmp(data->state.envproxy, proxy)) {
++        /* proxy changed */
++        Curl_auth_digest_cleanup(&data->state.proxydigest);
++        free(data->state.envproxy);
++        data->state.envproxy = Curl_cstrdup(proxy);
++      }
++#endif
+       /* force this connection's protocol to become HTTP if compatible */
+       if(!(conn->handler->protocol & PROTO_FAMILY_HTTP)) {
+         if((conn->handler->flags & PROTOPT_PROXY_AS_HTTP) &&
+diff --git a/lib/urldata.h b/lib/urldata.h
+index 540054632..5596b63a5 100644
+--- a/lib/urldata.h
++++ b/lib/urldata.h
+@@ -1369,6 +1369,9 @@ struct UrlState {
+ #ifdef HAVE_SIGNAL
+   /* storage for the previous bag^H^H^HSIGPIPE signal handler :-) */
+   void (*prev_signal)(int sig);
++#endif
++#ifndef CURL_DISABLE_CRYPTO_AUTH
++  char *envproxy; /* last proxy string used for proxy-related state */
+ #endif
+   struct digestdata digest;      /* state data for host Digest auth */
+   struct digestdata proxydigest; /* state data for proxy Digest auth */

--- a/meta-core/recipes-support/curl/curl_7.69.1.bbappend
+++ b/meta-core/recipes-support/curl/curl_7.69.1.bbappend
@@ -8,6 +8,14 @@ SRC_URI_append = " \
     file://CVE-2025-15079.patch \
     file://CVE-2025-15224.patch \
     file://CVE-2025-14017.patch \
+    file://CVE-2026-1965-1.patch \
+    file://CVE-2026-1965-2.patch \
+    file://CVE-2026-3783-pre1.patch \
+    file://CVE-2026-3783.patch \
+    file://CVE-2026-3784.patch \
+    file://CVE-2026-8927.patch \
+    file://CVE-2026-5773.patch \
+    file://CVE-2026-7168.patch \
     "
 
 # The use-after-free in question doesn't appear until 7.81.0, therefore we can


### PR DESCRIPTION
Backports CVE patches from kirkstone to dunfell for the following CVEs: CVE-2026-1965, CVE-2026-3783, CVE-2026-3784, CVE-2026-8927, CVE-2026-5773, CVE-2026-7168

Some newly added tests were omitted due to incompatibility with dunfell's curl version (7.69.1)