### PR TITLE
avahi: fix CVE-2026-34933

### DIFF
--- a/meta-core/recipes-connectivity/avahi/avahi/CVE-2026-34933-1.patch
+++ b/meta-core/recipes-connectivity/avahi/avahi/CVE-2026-34933-1.patch
@@ -1,0 +1,109 @@
+From 4daf7546e68cdb2bfce9ab1b71ed366909edcc76 Mon Sep 17 00:00:00 2001
+From: Evgeny Vereshchagin <evvers@ya.ru>
+Date: Wed, 1 Apr 2026 05:31:58 +0000
+Subject: [PATCH] core: refuse to accept publish flags where both wide_area and
+ multicast are set
+
+It fixes a bug where it was possible for unprivileged local users to
+crash avahi-daemon via D-Bus by calling EntryGroup methods accepting
+flags and passing both AVAHI_PUBLISH_USE_WIDE_AREA and
+AVAHI_PUBLISH_USE_MULTICAST there. For example when AddRecord was
+invoked like that avahi-daemon crashed with
+```
+dbus-entry-group.c: interface=org.freedesktop.Avahi.EntryGroup, path=/Client0/EntryGroup1, member=AddRecord
+avahi-daemon: entry.c:57: transport_flags_from_domain: Assertion `!((*flags & AVAHI_PUBLISH_USE_MULTICAST) && (*flags & AVAHI_PUBLISH_USE_WIDE_AREA))' failed.
+==84944==
+==84944== Process terminating with default action of signal 6 (SIGABRT)
+==84944==    at 0x4B353BC: __pthread_kill_implementation (pthread_kill.c:44)
+==84944==    by 0x4ADE941: raise (raise.c:26)
+==84944==    by 0x4AC64AB: abort (abort.c:77)
+==84944==    by 0x4AC641F: __assert_fail_base.cold (assert.c:118)
+==84944==    by 0x48A9404: transport_flags_from_domain (entry.c:57)
+==84944==    by 0x48A9F8F: server_add_internal (entry.c:224)
+==84944==    by 0x48AA49F: avahi_server_add (entry.c:324)
+==84944==    by 0x401A670: avahi_dbus_msg_entry_group_impl (dbus-entry-group.c:348)
+==84944==    by 0x4A70741: ??? (in /usr/lib/x86_64-linux-gnu/libdbus-1.so.3.38.3)
+==84944==    by 0x4A5FB22: dbus_connection_dispatch (in /usr/lib/x86_64-linux-gnu/libdbus-1.so.3.38.3)
+==84944==    by 0x401D01D: dispatch_timeout_callback (dbus-watch-glue.c:105)
+==84944==    by 0x488E3AE: timeout_callback (simple-watch.c:447)
+==84944==
+```
+It's a follow-up to fbce111b069aa1e4c701ed37ee1d9f6d6cefaac5 where
+those flags were introduced and consistent with the other places
+where wide_area/multicast flags are used.
+
+It was discovered by
+Guillaume Meunier - Head of Vulnerability Operations Center France - Orange Cyberdefense
+
+https://github.com/avahi/avahi/security/advisories/GHSA-w65r-6gxh-vhvc
+
+CVE-2026-34933
+
+CVE: CVE-2026-34933
+Upstream-Status: Backport [https://github.com/avahi/avahi/commit/0be89b6bb5c3983837b5e0febcbbbf452ecf7675]
+
+Signed-off-by: Colin Pinnell McAllister <colin.mcallister@garmin.com>
+---
+ avahi-core/entry.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/avahi-core/entry.c b/avahi-core/entry.c
+index 0d86213..06eb120 100644
+--- a/avahi-core/entry.c
++++ b/avahi-core/entry.c
+@@ -207,6 +207,7 @@ static AvahiEntry * server_add_internal(
+                                          AVAHI_PUBLISH_UPDATE|
+                                          AVAHI_PUBLISH_USE_WIDE_AREA|
+                                          AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
++    AVAHI_CHECK_VALIDITY_RETURN_NULL(s, !(flags & AVAHI_PUBLISH_USE_WIDE_AREA) || !(flags & AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
+     AVAHI_CHECK_VALIDITY_RETURN_NULL(s, avahi_is_valid_domain_name(r->key->name), AVAHI_ERR_INVALID_HOST_NAME);
+     AVAHI_CHECK_VALIDITY_RETURN_NULL(s, r->ttl != 0, AVAHI_ERR_INVALID_TTL);
+     AVAHI_CHECK_VALIDITY_RETURN_NULL(s, !avahi_key_is_pattern(r->key), AVAHI_ERR_IS_PATTERN);
+@@ -454,6 +455,7 @@ int avahi_server_add_address(
+                                               AVAHI_PUBLISH_UPDATE|
+                                               AVAHI_PUBLISH_USE_WIDE_AREA|
+                                               AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
++    AVAHI_CHECK_VALIDITY(s, !(flags & AVAHI_PUBLISH_USE_WIDE_AREA) || !(flags & AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
+     AVAHI_CHECK_VALIDITY(s, !name || avahi_is_valid_fqdn(name), AVAHI_ERR_INVALID_HOST_NAME);
+ 
+     /* Prepare the host naem */
+@@ -595,6 +597,7 @@ static int server_add_service_strlst_nocopy(
+                                                                 AVAHI_PUBLISH_UPDATE|
+                                                                 AVAHI_PUBLISH_USE_WIDE_AREA|
+                                                                 AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
++    AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, !(flags & AVAHI_PUBLISH_USE_WIDE_AREA) || !(flags & AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, avahi_is_valid_service_name(name), AVAHI_ERR_INVALID_SERVICE_NAME);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, avahi_is_valid_service_type_strict(type), AVAHI_ERR_INVALID_SERVICE_TYPE);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, !domain || avahi_is_valid_domain_name(domain), AVAHI_ERR_INVALID_DOMAIN_NAME);
+@@ -754,6 +757,7 @@ static int server_update_service_txt_strlst_nocopy(
+                                                                 AVAHI_PUBLISH_NO_COOKIE|
+                                                                 AVAHI_PUBLISH_USE_WIDE_AREA|
+                                                                 AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
++    AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, !(flags & AVAHI_PUBLISH_USE_WIDE_AREA) || !(flags & AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, avahi_is_valid_service_name(name), AVAHI_ERR_INVALID_SERVICE_NAME);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, avahi_is_valid_service_type_strict(type), AVAHI_ERR_INVALID_SERVICE_TYPE);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, !domain || avahi_is_valid_domain_name(domain), AVAHI_ERR_INVALID_DOMAIN_NAME);
+@@ -843,6 +847,7 @@ int avahi_server_add_service_subtype(
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, AVAHI_IF_VALID(interface), AVAHI_ERR_INVALID_INTERFACE);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, AVAHI_PROTO_VALID(protocol), AVAHI_ERR_INVALID_PROTOCOL);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, AVAHI_FLAGS_VALID(flags, AVAHI_PUBLISH_USE_MULTICAST|AVAHI_PUBLISH_USE_WIDE_AREA), AVAHI_ERR_INVALID_FLAGS);
++    AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, !(flags & AVAHI_PUBLISH_USE_WIDE_AREA) || !(flags & AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, avahi_is_valid_service_name(name), AVAHI_ERR_INVALID_SERVICE_NAME);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, avahi_is_valid_service_type_strict(type), AVAHI_ERR_INVALID_SERVICE_TYPE);
+     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, !domain || avahi_is_valid_domain_name(domain), AVAHI_ERR_INVALID_DOMAIN_NAME);
+@@ -910,6 +915,7 @@ static AvahiEntry *server_add_dns_server_name(
+     assert(name);
+ 
+     AVAHI_CHECK_VALIDITY_RETURN_NULL(s, AVAHI_FLAGS_VALID(flags, AVAHI_PUBLISH_USE_WIDE_AREA|AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
++    AVAHI_CHECK_VALIDITY_RETURN_NULL(s, !(flags & AVAHI_PUBLISH_USE_WIDE_AREA) || !(flags & AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
+     AVAHI_CHECK_VALIDITY_RETURN_NULL(s, type == AVAHI_DNS_SERVER_UPDATE || type == AVAHI_DNS_SERVER_RESOLVE, AVAHI_ERR_INVALID_FLAGS);
+     AVAHI_CHECK_VALIDITY_RETURN_NULL(s, port != 0, AVAHI_ERR_INVALID_PORT);
+     AVAHI_CHECK_VALIDITY_RETURN_NULL(s, avahi_is_valid_fqdn(name), AVAHI_ERR_INVALID_HOST_NAME);
+@@ -967,6 +973,7 @@ int avahi_server_add_dns_server_address(
+     AVAHI_CHECK_VALIDITY(s, AVAHI_IF_VALID(interface), AVAHI_ERR_INVALID_INTERFACE);
+     AVAHI_CHECK_VALIDITY(s, AVAHI_PROTO_VALID(protocol) && AVAHI_PROTO_VALID(address->proto), AVAHI_ERR_INVALID_PROTOCOL);
+     AVAHI_CHECK_VALIDITY(s, AVAHI_FLAGS_VALID(flags, AVAHI_PUBLISH_USE_MULTICAST|AVAHI_PUBLISH_USE_WIDE_AREA), AVAHI_ERR_INVALID_FLAGS);
++    AVAHI_CHECK_VALIDITY(s, !(flags & AVAHI_PUBLISH_USE_WIDE_AREA) || !(flags & AVAHI_PUBLISH_USE_MULTICAST), AVAHI_ERR_INVALID_FLAGS);
+     AVAHI_CHECK_VALIDITY(s, type == AVAHI_DNS_SERVER_UPDATE || type == AVAHI_DNS_SERVER_RESOLVE, AVAHI_ERR_INVALID_FLAGS);
+     AVAHI_CHECK_VALIDITY(s, port != 0, AVAHI_ERR_INVALID_PORT);
+     AVAHI_CHECK_VALIDITY(s, !domain || avahi_is_valid_domain_name(domain), AVAHI_ERR_INVALID_DOMAIN_NAME);

--- a/meta-core/recipes-connectivity/avahi/avahi/CVE-2026-34933-2.patch
+++ b/meta-core/recipes-connectivity/avahi/avahi/CVE-2026-34933-2.patch
@@ -1,0 +1,96 @@
+From 739c3ef777d599f93d77142c6afae173f8b7f2c8 Mon Sep 17 00:00:00 2001
+From: Evgeny Vereshchagin <evvers@ya.ru>
+Date: Wed, 1 Apr 2026 05:30:58 +0000
+Subject: [PATCH] tests: make sure AVAHI_PUBLISH_USE_WIDE_AREA is refused
+
+Change-Id: I89635e4466dba6b1a9abeae24adb14db2d3cd1a5
+
+CVE: CVE-2026-34933
+Upstream-Status: Backport [https://github.com/avahi/avahi/commit/a93fdd980d2db5d453475c0aa2b39946bd6611bd]
+
+Signed-off-by: Colin Pinnell McAllister <colin.mcallister@garmin.com>
+---
+ avahi-client/client-test.c | 25 +++++++++++++++++++++++++
+ avahi-core/avahi-test.c    | 12 +++++++++++-
+ 2 files changed, 36 insertions(+), 1 deletion(-)
+
+diff --git a/avahi-client/client-test.c b/avahi-client/client-test.c
+index 9a015d7..c80e12f 100644
+--- a/avahi-client/client-test.c
++++ b/avahi-client/client-test.c
+@@ -212,6 +212,28 @@ static void terminate(AVAHI_GCC_UNUSED AvahiTimeout *timeout, AVAHI_GCC_UNUSED v
+     avahi_simple_poll_quit(simple_poll);
+ }
+ 
++static void test_refuse_publish_flags(AvahiEntryGroup *g, AvahiPublishFlags flags, int expected) {
++    AvahiAddress a;
++    AvahiStringList *l = NULL;
++    int r;
++
++    r = avahi_entry_group_add_record(g, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, flags, "test.local", AVAHI_DNS_CLASS_IN, AVAHI_DNS_TYPE_CNAME, 120, "\0", 1);
++    assert(r == expected);
++
++    avahi_address_parse("224.0.0.251", AVAHI_PROTO_UNSPEC, &a);
++    r = avahi_entry_group_add_address(g, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, flags, "test.local", &a);
++    assert(r == expected);
++
++    r = avahi_entry_group_add_service_strlst(g, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, flags, "test", "_http._tcp", NULL, NULL, 80, l);
++    assert(r == expected);
++
++    r = avahi_entry_group_update_service_txt_strlst(g, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, flags, "test", "_http._tcp", NULL, l);
++    assert(r == expected);
++
++    r = avahi_entry_group_add_service_subtype(g, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, flags, "test", "_http._tcp", NULL, "_magic._sub._http._tcp");
++    assert(r == expected);
++}
++
+ int main (AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
+     AvahiClient *avahi;
+     AvahiEntryGroup *group, *group2;
+@@ -275,6 +297,9 @@ int main (AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
+     error = avahi_entry_group_add_record (group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0, "TestX", 0x01, 0x10, 120, "", 0);
+     assert(error != AVAHI_OK);
+ 
++    test_refuse_publish_flags(group, AVAHI_PUBLISH_USE_WIDE_AREA, AVAHI_ERR_NOT_SUPPORTED);
++    test_refuse_publish_flags(group, AVAHI_PUBLISH_USE_WIDE_AREA|AVAHI_PUBLISH_USE_MULTICAST, AVAHI_ERR_INVALID_FLAGS);
++
+     avahi_entry_group_commit (group);
+ 
+     domain = avahi_domain_browser_new (avahi, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, NULL, AVAHI_DOMAIN_BROWSER_BROWSE, 0, avahi_domain_browser_callback, (char*) "omghai3u");
+diff --git a/avahi-core/avahi-test.c b/avahi-core/avahi-test.c
+index 2a7872b..2bae82b 100644
+--- a/avahi-core/avahi-test.c
++++ b/avahi-core/avahi-test.c
+@@ -30,6 +30,7 @@
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+ 
++#include <avahi-common/error.h>
+ #include <avahi-common/malloc.h>
+ #include <avahi-common/simple-watch.h>
+ #include <avahi-common/alternative.h>
+@@ -150,6 +151,7 @@ static void remove_entries(void) {
+ static void create_entries(int new_name) {
+     AvahiAddress a;
+     AvahiRecord *r;
++    int error;
+ 
+     remove_entries();
+ 
+@@ -181,7 +183,15 @@ static void create_entries(int new_name) {
+         goto fail;
+     }
+ 
+-    if (avahi_server_add_dns_server_address(server, group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0, NULL, AVAHI_DNS_SERVER_RESOLVE, avahi_address_parse("192.168.50.1", AVAHI_PROTO_UNSPEC, &a), 53) < 0) {
++    avahi_address_parse("192.168.50.1", AVAHI_PROTO_UNSPEC, &a);
++
++    error = avahi_server_add_dns_server_address(server, group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, AVAHI_PUBLISH_USE_WIDE_AREA, NULL, AVAHI_DNS_SERVER_RESOLVE, &a, 53);
++    assert(error == AVAHI_ERR_NOT_SUPPORTED);
++
++    error = avahi_server_add_dns_server_address(server, group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, AVAHI_PUBLISH_USE_WIDE_AREA|AVAHI_PUBLISH_USE_MULTICAST, NULL, AVAHI_DNS_SERVER_RESOLVE, &a, 53);
++    assert(error == AVAHI_ERR_INVALID_FLAGS);
++
++    if (avahi_server_add_dns_server_address(server, group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0, NULL, AVAHI_DNS_SERVER_RESOLVE, &a, 53) < 0) {
+         avahi_log_error("Failed to add new DNS Server address");
+         goto fail;
+     }

--- a/meta-core/recipes-connectivity/avahi/avahi_0.8.bbappend
+++ b/meta-core/recipes-connectivity/avahi/avahi_0.8.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "\
+    file://CVE-2026-34933-1.patch \
+    file://CVE-2026-34933-2.patch \
+    "
+

--- a/meta-core/recipes-connectivity/openssl/openssl/0001-Don-t-raise-NOT_ENOUGH_DATA-on-a-clean-EOF-at-an-obj.patch
+++ b/meta-core/recipes-connectivity/openssl/openssl/0001-Don-t-raise-NOT_ENOUGH_DATA-on-a-clean-EOF-at-an-obj.patch
@@ -1,0 +1,316 @@
+From 1de813392a9d741006cc88390b464987a537e5ff Mon Sep 17 00:00:00 2001
+From: Marc Gutman <marcg@activestate.com>
+Date: Thu, 9 Jul 2026 15:23:28 -0500
+Subject: [PATCH 1/1] Don't raise NOT_ENOUGH_DATA on a clean EOF at an object
+ boundary
+
+asn1_d2i_read_bio() reads one ASN.1 object at a time from a BIO.  Callers
+commonly loop, decoding concatenated DER values until the call fails, and
+rely on a failure with no queued error to recognise a clean end of input.
+CPython's ssl module does this in _add_ca_certs() when loading the Windows
+certificate store via SSLContext.load_verify_locations(cadata=...); it
+re-raises any leftover ASN.1 error other than ASN1_R_HEADER_TOO_LONG as
+fatal.
+
+Commit 9eb6922c59 ("asn1: raise NOT_ENOUGH_DATA on header EOF") changed the
+BIO_read() check from "i < 0" to "i <= 0", so a clean EOF (BIO_read()
+returning 0, as an exhausted BIO_new_mem_buf does) on an object boundary now
+raises ASN1_R_NOT_ENOUGH_DATA instead of failing with an empty error queue.
+The rewrite in commit 35852da1d9 carried this behaviour forward.  As a
+result Python 3 on Windows fails to initialise an SSLContext with:
+
+    ssl.SSLError: [ASN1: NOT_ENOUGH_DATA] not enough data
+
+Raise ASN1_R_NOT_ENOUGH_DATA only on an actual read error, on an EOF in the
+middle of an object (some bytes already buffered), or on an EOF while still
+inside an indefinite-length value awaiting its end-of-contents octets - all
+of which are genuine truncation.  A clean EOF at a top-level object boundary
+again fails without queuing an error, restoring the long-standing behaviour
+that looping callers depend on.
+
+Add regression tests covering the clean-EOF, truncated, indefinite-length
+truncation and partial-header cases, and document the read behaviour in
+ASN1_item_d2i_bio(3).
+
+Fixes #31807
+
+Assisted-by: Claude:claude-opus-4-8
+
+Reviewed-by: Dmitry Belyavskiy <beldmit@gmail.com>
+Reviewed-by: Igor Ustinov <igus@openssl.foundation>
+Reviewed-by: Tomas Mraz <tomas@openssl.foundation>
+MergeDate: Mon Jul 13 08:05:03 2026
+(Merged from https://github.com/openssl/openssl/pull/31818)
+
+(cherry picked from commit d7e77b66cabb770932091ed5986221e0d1e57144)
+
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/d7e77b66cabb770932091ed5986221e0d1e57144]
+Signed-off-by: Colin Pinnell McAllister <colin.mcallister@garmin.com>
+---
+ crypto/asn1/a_d2i_fp.c         |  15 ++-
+ doc/man3/ASN1_item_d2i_bio.pod |  18 +++-
+ test/asn1_decode_test.c        | 165 +++++++++++++++++++++++++++++++++
+ 3 files changed, 196 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/asn1/a_d2i_fp.c b/crypto/asn1/a_d2i_fp.c
+index dcbb6d9a9e..f7d1026d92 100644
+--- a/crypto/asn1/a_d2i_fp.c
++++ b/crypto/asn1/a_d2i_fp.c
+@@ -139,7 +139,20 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
+             }
+             i = BIO_read(in, &(b->data[len]), want);
+             if (i <= 0) {
+-                ERR_raise(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA);
++                /*
++                 * A read error (i < 0), an EOF in the middle of an object
++                 * (diff != 0, some bytes already buffered), or an EOF while
++                 * still inside an indefinite-length constructed value awaiting
++                 * its end-of-contents octets (eos != 0) all mean the input is
++                 * truncated.  Only a clean EOF at a top-level object boundary
++                 * (i == 0, diff == 0, eos == 0) is the normal end of input:
++                 * fail without queuing an error so that callers looping over
++                 * concatenated DER values (e.g. the libcrypto d2i_*_bio()
++                 * consumers in CPython's ssl module) terminate cleanly instead
++                 * of seeing a spurious ASN1_R_NOT_ENOUGH_DATA.
++                 */
++                if (i < 0 || diff != 0 || eos != 0)
++                    ERR_raise(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA);
+                 goto err;
+             }
+             if (i > 0) {
+diff --git a/doc/man3/ASN1_item_d2i_bio.pod b/doc/man3/ASN1_item_d2i_bio.pod
+index bdf5c48096..d5c302f363 100644
+--- a/doc/man3/ASN1_item_d2i_bio.pod
++++ b/doc/man3/ASN1_item_d2i_bio.pod
+@@ -51,6 +51,16 @@ B<OSSL_LIB_CTX> provided in the I<libctx> parameter and the property query
+ string in I<propq>. See L<crypto(7)/ALGORITHM FETCHING> for more information
+ about algorithm fetching.
+ 
++When reading from I<in>, decoding consumes one complete DER-encoded structure
++and leaves any following bytes in the BIO, so concatenated structures can be
++read with successive calls. Reaching the end of the input cleanly, at a
++structure boundary, is not treated as an error: the function returns NULL
++without adding to the error queue. If the end of the input is reached in the
++middle of a structure, or an indefinite-length value is missing its
++end-of-contents octets (that is, the input is truncated), an error is queued
++with reason code B<ASN1_R_NOT_ENOUGH_DATA>. The same applies to
++ASN1_item_d2i_fp_ex().
++
+ ASN1_item_d2i_bio() is the same as ASN1_item_d2i_bio_ex() except that the
+ default B<OSSL_LIB_CTX> is used (i.e. NULL) and with a NULL property query
+ string.
+@@ -69,6 +79,12 @@ using the ASN.1 template I<it> and returns the result in a memory BIO.
+ 
+ ASN1_item_d2i_bio() returns a pointer to an B<ASN1_VALUE> or NULL.
+ 
++The ASN1_item_d2i_bio() and ASN1_item_d2i_fp() functions, including their
++B<_ex> variants, also return NULL at a clean end of input. In that case the
++error queue is left unchanged, so a caller reading concatenated structures in
++a loop can distinguish a clean end of input from a decoding error by
++inspecting the error queue, for example with L<ERR_peek_error(3)>.
++
+ ASN1_item_i2d_mem_bio() returns a pointer to a memory BIO or NULL on error.
+ 
+ =head1 HISTORY
+@@ -78,7 +94,7 @@ and ASN1_item_i2d_mem_bio() were added in OpenSSL 3.0.
+ 
+ =head1 COPYRIGHT
+ 
+-Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
++Copyright 2021-2026 The OpenSSL Project Authors. All Rights Reserved.
+ 
+ Licensed under the Apache License 2.0 (the "License").  You may not use
+ this file except in compliance with the License.  You can obtain a copy
+diff --git a/test/asn1_decode_test.c b/test/asn1_decode_test.c
+index 74bd30c95e..2feed6ba93 100644
+--- a/test/asn1_decode_test.c
++++ b/test/asn1_decode_test.c
+@@ -13,7 +13,11 @@
+ #include <openssl/rand.h>
+ #include <openssl/asn1t.h>
+ #include <openssl/obj_mac.h>
++#include <openssl/bio.h>
++#include <openssl/buffer.h>
++#include <openssl/err.h>
+ #include "internal/numbers.h"
++#include "internal/asn1.h"
+ #include "testutil.h"
+ 
+ #ifdef __GNUC__
+@@ -215,6 +219,163 @@ err:
+     return ret;
+ }
+ 
++/*
++ * A minimal, complete DER object: SEQUENCE { INTEGER 0 }.
++ * asn1_d2i_read_bio() should consume exactly these bytes.
++ */
++static const unsigned char one_obj[] = {
++    0x30, 0x03, /* SEQUENCE, length 3 */
++    0x02, 0x01, 0x00 /*   INTEGER 0        */
++};
++
++/*
++ * Reading concatenated DER objects from a BIO must stop cleanly at EOF:
++ * once the input is exhausted on an object boundary, asn1_d2i_read_bio()
++ * returns < 0 and must NOT leave an error on the queue.  Callers that loop
++ * over concatenated values (e.g. CPython's ssl module loading the Windows
++ * certificate store via d2i_X509_bio()) rely on this to detect end-of-input;
++ * a spurious ASN1_R_NOT_ENOUGH_DATA there is reported as a fatal error.
++ */
++static int test_d2i_read_bio_clean_eof(void)
++{
++    unsigned char two_objs[sizeof(one_obj) * 2];
++    BIO *bio = NULL;
++    BUF_MEM *buf = NULL;
++    int ret = 0;
++
++    memcpy(two_objs, one_obj, sizeof(one_obj));
++    memcpy(two_objs + sizeof(one_obj), one_obj, sizeof(one_obj));
++
++    if (!TEST_ptr(bio = BIO_new_mem_buf(two_objs, sizeof(two_objs))))
++        goto err;
++    ERR_clear_error();
++
++    /* Both complete objects are read, one per call. */
++    if (!TEST_int_eq(asn1_d2i_read_bio(bio, &buf), (int)sizeof(one_obj)))
++        goto err;
++    BUF_MEM_free(buf);
++    buf = NULL;
++    if (!TEST_int_eq(asn1_d2i_read_bio(bio, &buf), (int)sizeof(one_obj)))
++        goto err;
++    BUF_MEM_free(buf);
++    buf = NULL;
++
++    /* Clean EOF: failure return, but no error must be queued. */
++    if (!TEST_int_lt(asn1_d2i_read_bio(bio, &buf), 0))
++        goto err;
++    if (!TEST_ulong_eq(ERR_peek_error(), 0))
++        goto err;
++
++    ret = 1;
++err:
++    BUF_MEM_free(buf);
++    BIO_free(bio);
++    return ret;
++}
++
++/*
++ * In contrast, hitting EOF in the middle of an object is genuine truncation
++ * and must still be reported as ASN1_R_NOT_ENOUGH_DATA.
++ */
++static int test_d2i_read_bio_truncated(void)
++{
++    static const unsigned char truncated[] = {
++        0x30, 0x05, /* SEQUENCE claims 5 content bytes ... */
++        0x02, 0x01 /* ... but only 2 are present         */
++    };
++    BIO *bio = NULL;
++    BUF_MEM *buf = NULL;
++    unsigned long e;
++    int ret = 0;
++
++    if (!TEST_ptr(bio = BIO_new_mem_buf(truncated, sizeof(truncated))))
++        goto err;
++    ERR_clear_error();
++
++    if (!TEST_int_lt(asn1_d2i_read_bio(bio, &buf), 0))
++        goto err;
++    e = ERR_peek_last_error();
++    if (!TEST_int_eq(ERR_GET_LIB(e), ERR_LIB_ASN1)
++        || !TEST_int_eq(ERR_GET_REASON(e), ASN1_R_NOT_ENOUGH_DATA))
++        goto err;
++
++    ret = 1;
++err:
++    BUF_MEM_free(buf);
++    BIO_free(bio);
++    return ret;
++}
++
++/*
++ * An EOF reached while still inside an indefinite-length constructed value,
++ * before its end-of-contents octets, is truncation too (not a clean boundary),
++ * so it must also report ASN1_R_NOT_ENOUGH_DATA rather than an empty queue.
++ */
++static int test_d2i_read_bio_indefinite_truncated(void)
++{
++    /* SEQUENCE (indefinite) { INTEGER 0 } with the 00 00 EOC missing */
++    static const unsigned char truncated_indefinite[] = {
++        0x30, 0x80, /* SEQUENCE, indefinite length */
++        0x02, 0x01, 0x00 /* INTEGER 0; no end-of-contents octets follow */
++    };
++    BIO *bio = NULL;
++    BUF_MEM *buf = NULL;
++    unsigned long e;
++    int ret = 0;
++
++    bio = BIO_new_mem_buf(truncated_indefinite, sizeof(truncated_indefinite));
++    if (!TEST_ptr(bio))
++        goto err;
++    ERR_clear_error();
++
++    if (!TEST_int_lt(asn1_d2i_read_bio(bio, &buf), 0))
++        goto err;
++    e = ERR_peek_last_error();
++    if (!TEST_int_eq(ERR_GET_LIB(e), ERR_LIB_ASN1)
++        || !TEST_int_eq(ERR_GET_REASON(e), ASN1_R_NOT_ENOUGH_DATA))
++        goto err;
++
++    ret = 1;
++err:
++    BUF_MEM_free(buf);
++    BIO_free(bio);
++    return ret;
++}
++
++/*
++ * An EOF reached part-way through an object's header, with some header bytes
++ * already buffered, is truncation as well.  This exercises the "diff != 0" arm
++ * of the header-read check (distinct from the body read handled elsewhere).
++ */
++static int test_d2i_read_bio_partial_header(void)
++{
++    /* SEQUENCE with a 2-byte long-form length, but only one length byte given */
++    static const unsigned char partial_header[] = {
++        0x30, 0x82, 0x01 /* SEQUENCE, length declared as 2 bytes, 1 present */
++    };
++    BIO *bio = NULL;
++    BUF_MEM *buf = NULL;
++    unsigned long e;
++    int ret = 0;
++
++    if (!TEST_ptr(bio = BIO_new_mem_buf(partial_header, sizeof(partial_header))))
++        goto err;
++    ERR_clear_error();
++
++    if (!TEST_int_lt(asn1_d2i_read_bio(bio, &buf), 0))
++        goto err;
++    e = ERR_peek_last_error();
++    if (!TEST_int_eq(ERR_GET_LIB(e), ERR_LIB_ASN1)
++        || !TEST_int_eq(ERR_GET_REASON(e), ASN1_R_NOT_ENOUGH_DATA))
++        goto err;
++
++    ret = 1;
++err:
++    BUF_MEM_free(buf);
++    BIO_free(bio);
++    return ret;
++}
++
+ int setup_tests(void)
+ {
+ #ifndef OPENSSL_NO_DEPRECATED_3_0
+@@ -226,5 +387,9 @@ int setup_tests(void)
+     ADD_TEST(test_uint64);
+     ADD_TEST(test_invalid_template);
+     ADD_TEST(test_reuse_asn1_object);
++    ADD_TEST(test_d2i_read_bio_clean_eof);
++    ADD_TEST(test_d2i_read_bio_truncated);
++    ADD_TEST(test_d2i_read_bio_indefinite_truncated);
++    ADD_TEST(test_d2i_read_bio_partial_header);
+     return 1;
+ }
+-- 
+2.54.0
+

--- a/meta-core/recipes-connectivity/openssl/openssl_3.0.21.bb
+++ b/meta-core/recipes-connectivity/openssl/openssl_3.0.21.bb
@@ -12,6 +12,7 @@ SRC_URI = "https://github.com/openssl/openssl/releases/download/openssl-${PV}/op
            file://0001-buildinfo-strip-sysroot-and-debug-prefix-map-from-co.patch \
            file://afalg.patch \
            file://0001-Configure-do-not-tweak-mips-cflags.patch \
+		   file://0001-Don-t-raise-NOT_ENOUGH_DATA-on-a-clean-EOF-at-an-obj.patch \
           "
 
 SRC_URI:append:class-nativesdk = " \

--- a/scripts/build-aliases.csv
+++ b/scripts/build-aliases.csv
@@ -1,0 +1,1 @@
+avahi,avahi-dev

--- a/scripts/get-bitbake-targets.py
+++ b/scripts/get-bitbake-targets.py
@@ -9,6 +9,11 @@ NATIVE_ONLY_BPNS = {
     line.strip() for line in NATIVE_ONLY_FILE.read_text().splitlines() if line.strip()
 }
 
+BUILD_ALIAS_FILE = Path(__file__).resolve().parent / "build-aliases.csv"
+BUILD_ALIASES = {
+    k: v for k, v in [x.split(",") for x in BUILD_ALIAS_FILE.read_text().splitlines()]
+}
+
 
 class BPNFilter(Enum):
     ALL = "all"
@@ -97,22 +102,22 @@ def get_bpns(
         List[str]: All BPNs in the layer, or all associated BPNs if modified files are provided
     """
     bpns = get_modified_bpns(modified_files) if modified_files else get_all_bpns()
-    
+
     bpns = list(set(bpns))  # Remove duplicates
     bpns = list(filter(lambda bpn: bpn != "systemd", bpns))
     bpns = list(filter(lambda bpn: not bpn.startswith("linux-yocto"), bpns))
 
     if bpn_filter == BPNFilter.NATIVE:
-        return list(
+        bpns = list(
             filter(lambda bpn: bpn.removesuffix("-native") in NATIVE_ONLY_BPNS, bpns)
         )
     elif bpn_filter == BPNFilter.IMAGE:
-        return list(
+        bpns = list(
             filter(
                 lambda bpn: bpn.removesuffix("-native") not in NATIVE_ONLY_BPNS, bpns
             )
         )
-    return bpns
+    return sorted([BUILD_ALIASES.get(x, x) for x in bpns])
 
 
 def main() -> None:


### PR DESCRIPTION
Backport patch to fix CVE-2026-34933.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2026-34933
  https://www.cve.org/CVERecord?id=CVE-2026-34933
  https://security-tracker.debian.org/tracker/CVE-2026-34933
  https://ubuntu.com/security/CVE-2026-34933
  https://osv.dev/list?q=CVE-2026-34933

Upstream fix:
  debian:v0.9-rc4

> Note: This is an evaluation of [Ericsson/yocto-security-tools](https://github.com/Ericsson/yocto-security-tools) for fixing CVEs. The AI features have not been evaluated yet, this is an evaluation of `cve-metadata-extractor` and `cve-corrector`.

__Edit: But wait, there's more!__

- Adds feature to get-bitbake-targets.py to provide alias build targets instead of a `${PN}` to pass to bitbake
- Fixes OpenSSL issue that's causing Python ptests to fail

(See comments below for more details)