### PR TITLE
sqlite3: fix CVE-2026-11822 and CVE-2026-11824 (dunfell)

### DIFF
--- a/meta-core/recipes-support/sqlite3/sqlite3/CVE-2026-11822_CVE-2026-11824.patch
+++ b/meta-core/recipes-support/sqlite3/sqlite3/CVE-2026-11822_CVE-2026-11824.patch
@@ -1,0 +1,41 @@
+From 7ba5803935815a2b323354bd6c1c48187cfe66a2 Mon Sep 17 00:00:00 2001
+From: drh <>
+Date: Mon, 11 May 2026 12:00:19 +0000
+Subject: [PATCH] Fix potential buffer overwrite that could occur in fts5 when
+ processing corrupt records.
+
+FossilOrigin-Name: 061febcf41ca4872a0f407951e1507209daca7895122b909a7806c60b6e200c4
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-support/sqlite/sqlite3/CVE-2026-11822_CVE-2026-11824.patch?h=scarthgap
+
+CVE: CVE-2026-11822 CVE-2026-11824
+Upstream-Status: Backport [https://github.com/sqlite/sqlite/commit/e0b995b2a62b78979eb65bb8dadfa912eaa8e62f]
+
+Backport Changes:
+- Applied the upstream fts5LeafRead() fix from ext/fts5/fts5_index.c
+  to sqlite3.c because the Yocto sqlite-autoconf source uses the
+  amalgamated SQLite layout.
+- Omitted ext/fts5/test/fts5corruptA.test because this extracted
+  recipe source contains the SQLite autoconf/amalgamation layout and
+  does not carry the upstream Tcl test tree.
+- Omitted Git mirror metadata files manifest and manifest.uuid because
+  they are not required for the security fix in this source layout.
+
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+---
+ sqlite3.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sqlite3.c b/sqlite3.c
+index c645ac8..f183fff 100644
+--- a/sqlite3.c
++++ b/sqlite3.c
+@@ -215112,7 +215112,7 @@ static void fts5DataRelease(Fts5Data *pData){
+ static Fts5Data *fts5LeafRead(Fts5Index *p, i64 iRowid){
+   Fts5Data *pRet = fts5DataRead(p, iRowid);
+   if( pRet ){
+-    if( pRet->nn<4 || pRet->szLeaf>pRet->nn ){
++    if( pRet->szLeaf<4 || pRet->szLeaf>pRet->nn ){
+       p->rc = FTS5_CORRUPT;
+       fts5DataRelease(pRet);
+       pRet = 0;

--- a/meta-core/recipes-support/sqlite3/sqlite3_3.31.1.bbappend
+++ b/meta-core/recipes-support/sqlite3/sqlite3_3.31.1.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI_append = " \
     file://CVE-2025-70873.patch \
+    file://CVE-2026-11822_CVE-2026-11824.patch \
 "


### PR DESCRIPTION
Migrates the fix for CVE-2026-11822 and CVE-2026-11824 in sqlite3 from scarthgap to dunfell.

This patch applies the upstream fix [1], which addresses memory corruption vulnerabilities in the SQLite FTS5 full-text search extension. The GitHub mirror commit [1] corresponds to the SQLite Fossil check-in shown in [2].

[1] https://github.com/sqlite/sqlite/commit/e0b995b2a62b78979eb65bb8dadfa912eaa8e62f
[2] https://sqlite.org/src/info/061febcf41ca

Reference:
https://nvd.nist.gov/vuln/detail/CVE-2026-11822
https://nvd.nist.gov/vuln/detail/CVE-2026-11824