### PR TITLE
openssh: migrate scarthgap CVEs patch files [CVE-2026-59995 to CVE-2026-60001] (kirkstone)

### DIFF
--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59995.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59995.patch
@@ -1,0 +1,44 @@
+From 67ec8e332b478f6f490af2da41a9c0dc0c528cbf Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Mon, 29 Jun 2026 01:47:21 +0000
+Subject: [PATCH] upstream: avoid download to server-controlled path when
+ performing
+
+download on the commandline. From Swival scanner
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-connectivity/openssh/openssh/CVE-2026-59995.patch?h=scarthgap
+
+CVE: CVE-2026-59995
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/1b39f39657d2e58f8ec57341581a39bbf0be645b]
+
+Backport Changes:
+- Retained the Scarthgap sftp.c OpenBSD revision identifier because the
+  10.4 identifier does not describe the older source baseline.
+
+OpenBSD-Commit-ID: d1b2c44305fdfe6d51eed9ecc727e59478bf311f
+(cherry picked from commit 1b39f39657d2e58f8ec57341581a39bbf0be645b)
+Signed-off-by: Devansh Patel <devanshp@cisco.com>
+---
+ sftp.c | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/sftp.c b/sftp.c
+index 8cb5917..ea93fb5 100644
+--- a/sftp.c
++++ b/sftp.c
+@@ -2181,13 +2181,8 @@ interactive_loop(struct sftp_conn *conn, char *file1, char *file2)
+ 				return (-1);
+ 			}
+ 		} else {
+-			/* XXX this is wrong wrt quoting */
+-			snprintf(cmd, sizeof cmd, "get%s %s%s%s",
+-			    global_aflag ? " -a" : "", dir,
+-			    file2 == NULL ? "" : " ",
+-			    file2 == NULL ? "" : file2);
+-			err = parse_dispatch_command(conn, cmd,
+-			    &remote_path, startdir, 1, 0);
++			err = process_get(conn, dir, file2, remote_path, 0, 0,
++			    global_aflag, 0);
+ 			free(dir);
+ 			free(startdir);
+ 			free(remote_path);

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59996.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59996.patch
@@ -1,0 +1,36 @@
+From 5fd91937a9b0c280a131e5a6983b91ad315eeb4e Mon Sep 17 00:00:00 2001
+From: Andrej Koehler <Andrej.Koehler@garmin.com>
+Date: Tue, 11 Aug 2026 12:53:35 +0200
+Subject: [PATCH] upstream: resist that return ".." via remote glob during
+
+remote/remote copies, similar to fixes for bz3871 for remote/local copies.
+From Swival scanner
+
+CVE: CVE-2026-59996
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/36480181fa22f98e180b4f9e10203480c0346c78]
+
+Backport Changes:
+- Retained the scp.c OpenBSD revision identifier because the
+  10.4 identifier does not describe the older source baseline.
+
+OpenBSD-Commit-ID: c0c20a1b746db55c08e53658bf21ea9405b300a5
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ scp.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/scp.c b/scp.c
+index 2e37da4..53a56f5 100644
+--- a/scp.c
++++ b/scp.c
+@@ -1943,6 +1943,10 @@ throughlocal_sftp(struct sftp_conn *from, struct sftp_conn *to,
+ 			goto out;
+ 		}
+ 
++		/* Special handling for source of '..' */
++		if (strcmp(filename, "..") == 0)
++			filename = "."; /* Download to dest, not dest/.. */
++
+ 		if (targetisdir)
+ 			abs_dst = path_append(target, filename);
+ 		else

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59997.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59997.patch
@@ -1,0 +1,60 @@
+From 425c19311694d382e874ddb64594309cb6541f61 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Fri, 5 Jun 2026 08:53:07 +0000
+Subject: [PATCH] upstream: pass >9 commandline arguments to the internal-sftp
+ server,
+
+previously they were silently dropped; reported by Steve Caffrey ok deraadt@
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-connectivity/openssh/openssh/CVE-2026-59997.patch?h=scarthgap
+
+CVE: CVE-2026-59997
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/e9916c44c1324ab9ab022719e4df08a390a83014]
+
+Backport Changes:
+- Retained the Scarthgap session.c OpenBSD revision identifier because the
+  10.4 identifier does not describe the older source baseline.
+
+OpenBSD-Commit-ID: ee6cd5430a3ca027c3223af54b58ad3cc7ccd624
+(cherry picked from commit e9916c44c1324ab9ab022719e4df08a390a83014)
+Signed-off-by: Devansh Patel <devanshp@cisco.com>
+---
+ session.c | 19 ++++++++++---------
+ 1 file changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/session.c b/session.c
+index 625e97f..355b9c8 100644
+--- a/session.c
++++ b/session.c
+@@ -1650,21 +1650,22 @@ do_child(struct ssh *ssh, Session *s, const char *command)
+ 		exit(1);
+ 	} else if (s->is_subsystem == SUBSYSTEM_INT_SFTP) {
+ 		extern int optind, optreset;
+-		int i;
+-		char *p, *args;
++		int sftp_argc;
++		char **sftp_argv;
+ 
+ 		setproctitle("%s@%s", s->pw->pw_name, INTERNAL_SFTP_NAME);
+-		args = xstrdup(command ? command : "sftp-server");
+-		for (i = 0, (p = strtok(args, " ")); p; (p = strtok(NULL, " ")))
+-			if (i < ARGV_MAX - 1)
+-				argv[i++] = p;
+-		argv[i] = NULL;
++		if (argv_split(command == NULL ? "sftp-server" : command,
++		    &sftp_argc, &sftp_argv, 1) != 0) {
++			error("internal error: can't split internal-sftp "
++			    "arguments");
++			exit(1);
++		}
+ 		optind = optreset = 1;
+-		__progname = argv[0];
++		__progname = sftp_argv[0];
+ #ifdef WITH_SELINUX
+ 		ssh_selinux_change_context("sftpd_t");
+ #endif
+-		exit(sftp_server_main(i, argv, s->pw));
++		exit(sftp_server_main(sftp_argc, sftp_argv, s->pw));
+ 	}
+ 
+ 	fflush(NULL);

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59999.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59999.patch
@@ -1,0 +1,38 @@
+From 08ac09857fe464d34d527492ff63498b5a99ef70 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Sun, 31 May 2026 04:47:29 +0000
+Subject: [PATCH] upstream: DisableForwarding=yes didn't override
+ PermitTunnel=yes
+
+Reported independently by Huzaifa Sidhpurwala of Redhat and Marko
+Jevtic; ok markus@
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-connectivity/openssh/openssh/CVE-2026-59999.patch?h=scarthgap
+
+CVE: CVE-2026-59999
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/8dfe7ed6e2fd988de08df508355a196b956b2753]
+
+Backport Changes:
+- Retained the Scarthgap serverloop.c OpenBSD revision identifier because
+  the 10.4 identifier does not describe the older source baseline.
+
+OpenBSD-Commit-ID: b5c13f0746cf079b21f8deba47407fad49ccbf4c
+(cherry picked from commit 8dfe7ed6e2fd988de08df508355a196b956b2753)
+Signed-off-by: Devansh Patel <devanshp@cisco.com>
+---
+ serverloop.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/serverloop.c b/serverloop.c
+index 0541f02..aa4025a 100644
+--- a/serverloop.c
++++ b/serverloop.c
+@@ -535,7 +535,7 @@ server_request_tun(struct ssh *ssh)
+ 		ssh_packet_send_debug(ssh, "Unsupported tunnel device mode.");
+ 		return NULL;
+ 	}
+-	if ((options.permit_tun & mode) == 0) {
++	if ((options.permit_tun & mode) == 0 || options.disable_forwarding) {
+ 		ssh_packet_send_debug(ssh, "Server has rejected tunnel device "
+ 		    "forwarding");
+ 		return NULL;

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-60000.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-60000.patch
@@ -1,0 +1,142 @@
+From c6a75663dfc7d3e850895bee36c22755f53f4ad5 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Mon, 6 Jul 2026 07:53:30 +0000
+Subject: [PATCH] upstream: Fix multiple RFC 4462 (GSSAPIAuthentication)
+ compliance
+
+problems
+
+1) Remove an early failure return for GSSAPI authentication attempts
+made for invalid accounts that yielded different behaviour for
+valid vs invalid accounts.
+
+2) Fix a situation where some GSSAPI requestes were not correctly
+subjected to MaxAuthTries.
+
+3) Fix a moderate pre-authentication resource DoS related to #2.
+
+Add missing logging for error cases.
+
+Report and fixes from Manfred Kaiser, milCERT AT
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-connectivity/openssh/openssh/CVE-2026-60000.patch?h=scarthgap
+
+CVE: CVE-2026-60000
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/5d04ca6af739b82fd30d84d2783ca802ebfa1192]
+
+Backport Changes:
+- Kept Scarthgap's PRIVSEP(ssh_gssapi_server_ctx()) interface and its
+  authentication-context guard while applying the upstream RFC 4462 state,
+  failure, logging, and MaxAuthTries changes.
+- Retained the Scarthgap auth2-gss.c OpenBSD revision identifier.
+
+OpenBSD-Commit-ID: ca0acdd64eea435d6f89534538a9eb404a5629d3
+(cherry picked from commit 5d04ca6af739b82fd30d84d2783ca802ebfa1192)
+Signed-off-by: Devansh Patel <devanshp@cisco.com>
+---
+ auth2-gss.c | 53 ++++++++++++++++++++++++-----------------------------
+ 1 file changed, 24 insertions(+), 29 deletions(-)
+
+diff --git a/auth2-gss.c b/auth2-gss.c
+index 3249dba..6bac55f 100644
+--- a/auth2-gss.c
++++ b/auth2-gss.c
+@@ -104,12 +104,6 @@ userauth_gssapi(struct ssh *ssh, const char *method)
+ 		return (0);
+ 	}
+ 
+-	if (!authctxt->valid || authctxt->user == NULL) {
+-		debug2_f("disabled because of invalid user");
+-		free(doid);
+-		return (0);
+-	}
+-
+ 	if (GSS_ERROR(PRIVSEP(ssh_gssapi_server_ctx(&ctxt, &goid)))) {
+ 		if (ctxt != NULL)
+ 			ssh_gssapi_delete_ctx(&ctxt);
+@@ -171,8 +165,14 @@ input_gssapi_token(int type, u_int32_t plen, struct ssh *ssh)
+ 			    (r = sshpkt_send(ssh)) != 0)
+ 				fatal_fr(r, "send ERRTOK packet");
+ 		}
++		logit("Failed gssapi-with-mic for %s%.100s "
++		    "from %.200s port %d ssh2",
++		    authctxt->valid ? "" : "invalid user ",
++		    authctxt->user,
++		    ssh_remote_ipaddr(ssh), ssh_remote_port(ssh));
+ 		authctxt->postponed = 0;
+ 		ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_TOKEN, NULL);
++		ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_ERRTOK, NULL);
+ 		userauth_finish(ssh, 0, "gssapi-with-mic", NULL);
+ 	} else {
+ 		if (send_tok.length != 0) {
+@@ -184,14 +184,18 @@ input_gssapi_token(int type, u_int32_t plen, struct ssh *ssh)
+ 				fatal_fr(r, "send TOKEN packet");
+ 		}
+ 		if (maj_status == GSS_S_COMPLETE) {
+-			ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_TOKEN, NULL);
+-			if (flags & GSS_C_INTEG_FLAG)
+-				ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_MIC,
++			ssh_dispatch_set(ssh,
++			    SSH2_MSG_USERAUTH_GSSAPI_TOKEN, NULL);
++			/* note: keep ERRTOK handler as per RFC 4462 s3.4 */
++			if (flags & GSS_C_INTEG_FLAG) {
++				ssh_dispatch_set(ssh,
++				    SSH2_MSG_USERAUTH_GSSAPI_MIC,
+ 				    &input_gssapi_mic);
+-			else
++			} else {
+ 				ssh_dispatch_set(ssh,
+ 				    SSH2_MSG_USERAUTH_GSSAPI_EXCHANGE_COMPLETE,
+ 				    &input_gssapi_exchange_complete);
++			}
+ 		}
+ 	}
+ 
+@@ -203,10 +207,6 @@ static int
+ input_gssapi_errtok(int type, u_int32_t plen, struct ssh *ssh)
+ {
+ 	Authctxt *authctxt = ssh->authctxt;
+-	Gssctxt *gssctxt;
+-	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
+-	gss_buffer_desc recv_tok;
+-	OM_uint32 maj_status;
+ 	int r;
+ 	u_char *p;
+ 	size_t len;
+@@ -214,26 +214,21 @@ input_gssapi_errtok(int type, u_int32_t plen, struct ssh *ssh)
+ 	if (authctxt == NULL || (authctxt->methoddata == NULL && !use_privsep))
+ 		fatal("No authentication or GSSAPI context");
+ 
+-	gssctxt = authctxt->methoddata;
+-	if ((r = sshpkt_get_string(ssh, &p, &len)) != 0 ||
++	/* Minimal error handling - just cancel auth and return FAILURE */
++	if ((r = sshpkt_get_string_direct(ssh, NULL, NULL)) != 0 ||
+ 	    (r = sshpkt_get_end(ssh)) != 0)
+ 		fatal_fr(r, "parse packet");
+-	recv_tok.value = p;
+-	recv_tok.length = len;
+-
+-	/* Push the error token into GSSAPI to see what it says */
+-	maj_status = PRIVSEP(ssh_gssapi_accept_ctx(gssctxt, &recv_tok,
+-	    &send_tok, NULL));
+-
+-	free(recv_tok.value);
+ 
+-	/* We can't return anything to the client, even if we wanted to */
++	logit("Failed gssapi-with-mic for %s%.100s from %.200s port %d ssh2",
++	    authctxt->valid ? "" : "invalid user ",
++	    authctxt->user,
++	    ssh_remote_ipaddr(ssh), ssh_remote_port(ssh));
++	authctxt->postponed = 0;
+ 	ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_TOKEN, NULL);
+ 	ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_ERRTOK, NULL);
+-
+-	/* The client will have already moved on to the next auth */
+-
+-	gss_release_buffer(&maj_status, &send_tok);
++	ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_MIC, NULL);
++	ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_EXCHANGE_COMPLETE, NULL);
++	userauth_finish(ssh, 0, "gssapi-with-mic", NULL);
+ 	return 0;
+ }
+ 

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-60001.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-60001.patch
@@ -1,0 +1,133 @@
+From 9229d172968fabec20df13839ad8cf2520f876b0 Mon Sep 17 00:00:00 2001
+From: Andrej Koehler <akhldev@proton.me>
+Date: Tue, 11 Aug 2026 13:06:27 +0200
+Subject: [PATCH] upstream: Fix cases in GSSAPI and keyboard-interactive
+
+authentication where the minimum per-attempt delay was not being enforced.
+
+Reported by Orange Cyberdefense Vulnerability Team
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-connectivity/openssh/openssh/CVE-2026-60001.patch?h=scarthgap
+
+CVE: CVE-2026-60001
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/d43ba60c91cb323ca921049b7d43b1908c318454]
+
+Backport Changes:
+- Kept Scarthgap's PRIVSEP(ssh_gssapi_userok()) interface and GSSAPI
+  display-name recording while adding the upstream failure-delay calls;
+  mm_ssh_gssapi_userok() belongs to the later split-sshd architecture.
+- Retained the Scarthgap OpenBSD revision identifiers in auth.h,
+  auth2-chall.c, auth2-gss.c, and auth2.c.
+
+OpenBSD-Commit-ID: c40bd35cc2428fcaccad7a141703c28baa6da01e
+(cherry picked from commit d43ba60c91cb323ca921049b7d43b1908c318454)
+Signed-off-by: Devansh Patel <devanshp@cisco.com>
+[manually applied the scarthgap patch file]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ auth.h        | 1 +
+ auth2-chall.c | 4 ++++
+ auth2-gss.c   | 7 +++++++
+ auth2.c       | 9 +++++++--
+ 4 files changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/auth.h b/auth.h
+index a65d8fd..f834840 100644
+--- a/auth.h
++++ b/auth.h
+@@ -171,6 +171,7 @@ void	auth_log(struct ssh *, int, int, const char *, const char *);
+ void	auth_maxtries_exceeded(struct ssh *) __attribute__((noreturn));
+ void	userauth_finish(struct ssh *, int, const char *, const char *);
+ int	auth_root_allowed(struct ssh *, const char *);
++void	auth_failure_delay(Authctxt *, double);
+ 
+ char	*auth2_read_banner(void);
+ int	 auth2_methods_valid(const char *, int);
+diff --git a/auth2-chall.c b/auth2-chall.c
+index 021df82..20e70d2 100644
+--- a/auth2-chall.c
++++ b/auth2-chall.c
+@@ -296,6 +296,7 @@ input_userauth_info_response(int type, u_int32_t seq, struct ssh *ssh)
+ 	u_int i, nresp;
+ 	const char *devicename = NULL;
+ 	char **response = NULL;
++	double tstart = monotime_double();
+ 
+ 	if (authctxt == NULL)
+ 		fatal_f("no authctxt");
+@@ -354,6 +355,9 @@ input_userauth_info_response(int type, u_int32_t seq, struct ssh *ssh)
+ 			auth2_challenge_start(ssh);
+ 		}
+ 	}
++
++	if (!authenticated)
++		auth_failure_delay(authctxt, tstart);
+ 	userauth_finish(ssh, authenticated, "keyboard-interactive",
+ 	    devicename);
+ 	return 0;
+diff --git a/auth2-gss.c b/auth2-gss.c
+index 2062609..3249dba 100644
+--- a/auth2-gss.c
++++ b/auth2-gss.c
+@@ -249,6 +249,7 @@ input_gssapi_exchange_complete(int type, u_int32_t plen, struct ssh *ssh)
+ 	Authctxt *authctxt = ssh->authctxt;
+ 	int r, authenticated;
+ 	const char *displayname;
++	double tstart = monotime_double();
+ 
+ 	if (authctxt == NULL || (authctxt->methoddata == NULL && !use_privsep))
+ 		fatal("No authentication or GSSAPI context");
+@@ -262,6 +263,8 @@ input_gssapi_exchange_complete(int type, u_int32_t plen, struct ssh *ssh)
+ 		fatal_fr(r, "parse packet");
+ 
+ 	authenticated = PRIVSEP(ssh_gssapi_userok(authctxt->user));
++	if (!authenticated)
++		auth_failure_delay(authctxt, tstart);
+ 
+ 	if ((!use_privsep || mm_is_monitor()) &&
+ 	    (displayname = ssh_gssapi_displayname()) != NULL)
+@@ -287,6 +290,7 @@ input_gssapi_mic(int type, u_int32_t plen, struct ssh *ssh)
+ 	const char *displayname;
+ 	u_char *p;
+ 	size_t len;
++	double tstart = monotime_double();
+ 
+ 	if (authctxt == NULL || (authctxt->methoddata == NULL && !use_privsep))
+ 		fatal("No authentication or GSSAPI context");
+@@ -314,6 +318,9 @@ input_gssapi_mic(int type, u_int32_t plen, struct ssh *ssh)
+ 	sshbuf_free(b);
+ 	free(mic.value);
+ 
++	if (!authenticated)
++		auth_failure_delay(authctxt, tstart);
++
+ 	if ((!use_privsep || mm_is_monitor()) &&
+ 	    (displayname = ssh_gssapi_displayname()) != NULL)
+ 		auth2_record_info(authctxt, "%s", displayname);
+diff --git a/auth2.c b/auth2.c
+index 6c06193..9ca303f 100644
+--- a/auth2.c
++++ b/auth2.c
+@@ -256,6 +256,12 @@ ensure_minimum_time_since(double start, double seconds)
+ 	nanosleep(&ts, NULL);
+ }
+ 
++void
++auth_failure_delay(Authctxt *authctxt, double tstart)
++{
++	ensure_minimum_time_since(tstart, user_specific_delay(authctxt->user));
++}
++
+ /*ARGSUSED*/
+ static int
+ input_userauth_request(int type, u_int32_t seq, struct ssh *ssh)
+@@ -338,8 +344,7 @@ input_userauth_request(int type, u_int32_t seq, struct ssh *ssh)
+ 		authenticated =	m->userauth(ssh, method);
+ 	}
+ 	if (!authctxt->authenticated)
+-		ensure_minimum_time_since(tstart,
+-		    user_specific_delay(authctxt->user));
++		auth_failure_delay(authctxt, tstart);
+ 	userauth_finish(ssh, authenticated, method, NULL);
+ 	r = 0;
+  out:

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -11,4 +11,5 @@ SRC_URI:append = " \
     file://CVE-2026-35388.patch \
     file://CVE-2026-35414.patch \
     file://CVE-2026-59999.patch \
+    file://CVE-2026-59997.patch \
     "

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -14,4 +14,5 @@ SRC_URI:append = " \
     file://CVE-2026-59997.patch \
     file://CVE-2026-59996.patch \
     file://CVE-2026-59995.patch \
+    file://CVE-2026-60001.patch \
     "

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -12,4 +12,5 @@ SRC_URI:append = " \
     file://CVE-2026-35414.patch \
     file://CVE-2026-59999.patch \
     file://CVE-2026-59997.patch \
+    file://CVE-2026-59996.patch \
     "

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -21,3 +21,8 @@ SRC_URI:append = " \
 # https://nvd.nist.gov/vuln/detail/CVE-2026-3497
 # not-applicable-platform: Only affects GSSAPI Key Exchange patches used by some Linux distributions and does not exist in upstream openssh.
 CVE_CHECK_IGNORE += "CVE-2026-3497"
+
+# https://nvd.nist.gov/vuln/detail/CVE-2026-59998
+# Only relevant when Kerberos support is disabled.
+# not-applicable-config: GSSAPI/Kerberos support is disabled in the default OpenSSH configuration
+CVE_CHECK_IGNORE += "${@bb.utils.contains('PACKAGECONFIG', 'kerberos', '', 'CVE-2026-59998', d)}"

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -15,4 +15,5 @@ SRC_URI:append = " \
     file://CVE-2026-59996.patch \
     file://CVE-2026-59995.patch \
     file://CVE-2026-60001.patch \
+    file://CVE-2026-60000.patch \
     "

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -13,4 +13,5 @@ SRC_URI:append = " \
     file://CVE-2026-59999.patch \
     file://CVE-2026-59997.patch \
     file://CVE-2026-59996.patch \
+    file://CVE-2026-59995.patch \
     "

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -10,4 +10,5 @@ SRC_URI:append = " \
     file://CVE-2026-60002.patch \
     file://CVE-2026-35388.patch \
     file://CVE-2026-35414.patch \
+    file://CVE-2026-59999.patch \
     "

--- a/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -17,3 +17,7 @@ SRC_URI:append = " \
     file://CVE-2026-60001.patch \
     file://CVE-2026-60000.patch \
     "
+
+# https://nvd.nist.gov/vuln/detail/CVE-2026-3497
+# not-applicable-platform: Only affects GSSAPI Key Exchange patches used by some Linux distributions and does not exist in upstream openssh.
+CVE_CHECK_IGNORE += "CVE-2026-3497"


### PR DESCRIPTION
Migrated several CVE patch files from scarthgap for openssh.
CVE-2026-59995 up to CVE-2026-60001 and CVE-2026-3497 

Most of the patch files apply cleanly.
Two patch files could not be applied automatically. Applied the diff hunks manually.

Verification: Compiles, openssh ptests local run PASS