### PR TITLE
openssh: migrate scarthgap CVEs patch files [CVE-2026-59995 to CVE-2026-60001] (dunfell)

### DIFF
--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35388.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35388.patch
@@ -1,0 +1,40 @@
+From d072734341c878245fad91e33f358b6ef8e00e43 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:39:57 +0000
+Subject: [PATCH] upstream: add missing askpass check when using
+
+ControlMaster=ask/autoask and "ssh -O proxy ..."; reported by Michalis
+Vasileiadis
+
+OpenBSD-Commit-ID: 8dd7b9b96534e9a8726916b96d36bed466d3836a
+
+(cherry picked from commit c805b97b67c774e0bf922ffb29dfbcda9d7b5add)
+
+CVE: CVE-2026-35388
+Upstream-Status: Backport [https://anongit.mindrot.org/openssh.git/commit/?id=c805b97b67c774e0bf922ffb29dfbcda9d7b5add]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ mux.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/mux.c b/mux.c
+index 5efc849c4..102ada9d9 100644
+--- a/mux.c
++++ b/mux.c
+@@ -1146,6 +1146,16 @@ mux_master_process_proxy(struct ssh *ssh, u_int rid,
+ 
+ 	debug("%s: channel %d: proxy request", __func__, c->self);
+ 
++	if (options.control_master == SSHCTL_MASTER_ASK ||
++	    options.control_master == SSHCTL_MASTER_AUTO_ASK) {
++		if (!ask_permission("Allow multiplex proxy connection?")) {
++			debug2("%s: proxy refused by user", __func__);
++			reply_error(reply, MUX_S_PERMISSION_DENIED, rid,
++			    "Permission denied");
++			return 0;
++		}
++	}
++
+ 	c->mux_rcb = channel_proxy_downstream;
+ 	if ((r = sshbuf_put_u32(reply, MUX_S_PROXY)) != 0 ||
+ 	    (r = sshbuf_put_u32(reply, rid)) != 0)

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35414.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-35414.patch
@@ -1,0 +1,72 @@
+From 7044d4cd8228ca174d4d9eb621ec567d489253c1 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:48:13 +0000
+Subject: [PATCH] sshd(8): fix inappropriate matching of authorized_keys
+ principals
+
+When matching an authorized_keys principals="" option against a list of
+principals in a certificate, an incorrect algorithm was used that could
+allow inappropriate matching in cases where a principal name in the
+certificate contains a comma character. Exploitation of the condition
+requires an authorized_keys principals="" option that lists more than
+one principal *and* a CA that will issue a certificate that encodes more
+than one of these principal names separated by a comma (typical CAs
+strongly constrain which principal names they will place in a
+certificate). This condition only applies to user- trusted CA keys in
+authorized_keys, the main certificate authentication path
+(TrustedUserCAKeys/AuthorizedPrincipalsFile) is not affected.
+
+Reported by Vladimir Tokarev.
+
+OpenBSD-Commit-ID: c790e2687c35989ae34a00e709be935c55b16a86
+
+[cjwatson: Committed upstream together with apparently-unrelated changes
+for CVE-2026-35387.  I've split them into separate patches for clarity.]
+
+Origin: debian, https://salsa.debian.org/ssh-team/openssh/-/commit/ae190b6440b7c599d759527965334eeb49cc75b3?file_path=debian%2Fpatches%2FCVE-2026-35414.patch#2c991424baccc1d7a6f0d84ccc77bfe7ccdda848
+
+CVE: CVE-2026-35414
+Upstream-Status: Backport [https://anongit.mindrot.org/openssh.git/commit/?id=fd1c7e131f331942d20f42f31e79912d570081fa]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ auth2-pubkey.c | 23 +++++++++++++----------
+ 1 file changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/auth2-pubkey.c b/auth2-pubkey.c
+index b42f4e1c3..36e519428 100644
+--- a/auth2-pubkey.c
++++ b/auth2-pubkey.c
+@@ -299,20 +299,23 @@ done:
+ static int
+ match_principals_option(const char *principal_list, struct sshkey_cert *cert)
+ {
+-	char *result;
++	char *list, *olist, *entry;
+ 	u_int i;
+ 
+-	/* XXX percent_expand() sequences for authorized_principals? */
+-
+-	for (i = 0; i < cert->nprincipals; i++) {
+-		if ((result = match_list(cert->principals[i],
+-		    principal_list, NULL)) != NULL) {
+-			debug3("matched principal from key options \"%.100s\"",
+-			    result);
+-			free(result);
+-			return 1;
++	olist = list = xstrdup(principal_list);
++	for (;;) {
++		if ((entry = strsep(&list, ",")) == NULL || *entry == '\0')
++			break;
++		for (i = 0; i < cert->nprincipals; i++) {
++			if (strcmp(entry, cert->principals[i]) == 0) {
++				debug3("matched principal from key i"
++				    "options \"%.100s\"", entry);
++				free(olist);
++				return 1;
++			}
+ 		}
+ 	}
++	free(olist);
+ 	return 0;
+ }
+ 

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59995.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59995.patch
@@ -1,0 +1,44 @@
+From 54f3d399e8c4e4b96e9aecabb7a02ddc1c16cad3 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Mon, 29 Jun 2026 01:47:21 +0000
+Subject: [PATCH] upstream: avoid download to server-controlled path when
+ performing
+
+download on the commandline. From Swival scanner
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-connectivity/openssh/openssh/CVE-2026-59995.patch?h=scarthgap
+
+CVE: CVE-2026-59995
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/1b39f39657d2e58f8ec57341581a39bbf0be645b]
+
+Backport Changes:
+- Retained the Scarthgap sftp.c OpenBSD revision identifier because the
+  10.4 identifier does not describe the older source baseline.
+
+OpenBSD-Commit-ID: d1b2c44305fdfe6d51eed9ecc727e59478bf311f
+(cherry picked from commit 1b39f39657d2e58f8ec57341581a39bbf0be645b)
+Signed-off-by: Devansh Patel <devanshp@cisco.com>
+---
+ sftp.c | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/sftp.c b/sftp.c
+index ff14d3c29..13eef2bd2 100644
+--- a/sftp.c
++++ b/sftp.c
+@@ -2221,13 +2221,8 @@ interactive_loop(struct sftp_conn *conn, char *file1, char *file2)
+ 				return (-1);
+ 			}
+ 		} else {
+-			/* XXX this is wrong wrt quoting */
+-			snprintf(cmd, sizeof cmd, "get%s %s%s%s",
+-			    global_aflag ? " -a" : "", dir,
+-			    file2 == NULL ? "" : " ",
+-			    file2 == NULL ? "" : file2);
+-			err = parse_dispatch_command(conn, cmd,
+-			    &remote_path, startdir, 1, 0);
++			err = process_get(conn, dir, file2, remote_path, 0, 0,
++			    global_aflag, 0);
+ 			free(dir);
+ 			free(startdir);
+ 			free(remote_path);

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59997.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59997.patch
@@ -1,0 +1,63 @@
+From dc273d4af90f791055accb88e45500100ddbbfa9 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Fri, 5 Jun 2026 08:53:07 +0000
+Subject: [PATCH] upstream: pass >9 commandline arguments to the internal-sftp
+ server,
+
+previously they were silently dropped; reported by Steve Caffrey ok deraadt@
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-connectivity/openssh/openssh/CVE-2026-59997.patch?h=scarthgap
+
+CVE: CVE-2026-59997
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/e9916c44c1324ab9ab022719e4df08a390a83014]
+
+Backport Changes:
+- Retained the Scarthgap session.c OpenBSD revision identifier because the
+  10.4 identifier does not describe the older source baseline.
+
+OpenBSD-Commit-ID: ee6cd5430a3ca027c3223af54b58ad3cc7ccd624
+(cherry picked from commit e9916c44c1324ab9ab022719e4df08a390a83014)
+Signed-off-by: Devansh Patel <devanshp@cisco.com>
+[removed additional argument (terminate_on_comment) to argv_split() in
+session.c, it is not present in 8.2p1]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ session.c | 19 ++++++++++---------
+ 1 file changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/session.c b/session.c
+index 70ffdeb26..d2b91fb78 100644
+--- a/session.c
++++ b/session.c
+@@ -1652,21 +1652,22 @@ do_child(struct ssh *ssh, Session *s, const char *command)
+ 		exit(1);
+ 	} else if (s->is_subsystem == SUBSYSTEM_INT_SFTP) {
+ 		extern int optind, optreset;
+-		int i;
+-		char *p, *args;
++		int sftp_argc;
++		char **sftp_argv;
+ 
+ 		setproctitle("%s@%s", s->pw->pw_name, INTERNAL_SFTP_NAME);
+-		args = xstrdup(command ? command : "sftp-server");
+-		for (i = 0, (p = strtok(args, " ")); p; (p = strtok(NULL, " ")))
+-			if (i < ARGV_MAX - 1)
+-				argv[i++] = p;
+-		argv[i] = NULL;
++		if (argv_split(command == NULL ? "sftp-server" : command,
++		    &sftp_argc, &sftp_argv) != 0) {
++			error("internal error: can't split internal-sftp "
++			    "arguments");
++			exit(1);
++		}
+ 		optind = optreset = 1;
+-		__progname = argv[0];
++		__progname = sftp_argv[0];
+ #ifdef WITH_SELINUX
+ 		ssh_selinux_change_context("sftpd_t");
+ #endif
+-		exit(sftp_server_main(i, argv, s->pw));
++		exit(sftp_server_main(sftp_argc, sftp_argv, s->pw));
+ 	}
+ 
+ 	fflush(NULL);

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59999.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-59999.patch
@@ -1,0 +1,38 @@
+From a9627c7438710cafee2e3c4dabb2a18ebc672b8f Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Sun, 31 May 2026 04:47:29 +0000
+Subject: [PATCH] upstream: DisableForwarding=yes didn't override
+ PermitTunnel=yes
+
+Reported independently by Huzaifa Sidhpurwala of Redhat and Marko
+Jevtic; ok markus@
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-connectivity/openssh/openssh/CVE-2026-59999.patch?h=scarthgap
+
+CVE: CVE-2026-59999
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/8dfe7ed6e2fd988de08df508355a196b956b2753]
+
+Backport Changes:
+- Retained the Scarthgap serverloop.c OpenBSD revision identifier because
+  the 10.4 identifier does not describe the older source baseline.
+
+OpenBSD-Commit-ID: b5c13f0746cf079b21f8deba47407fad49ccbf4c
+(cherry picked from commit 8dfe7ed6e2fd988de08df508355a196b956b2753)
+Signed-off-by: Devansh Patel <devanshp@cisco.com>
+---
+ serverloop.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/serverloop.c b/serverloop.c
+index 340b19a5a..32e837f34 100644
+--- a/serverloop.c
++++ b/serverloop.c
+@@ -586,7 +586,7 @@ server_request_tun(struct ssh *ssh)
+ 		ssh_packet_send_debug(ssh, "Unsupported tunnel device mode.");
+ 		return NULL;
+ 	}
+-	if ((options.permit_tun & mode) == 0) {
++	if ((options.permit_tun & mode) == 0 || options.disable_forwarding) {
+ 		ssh_packet_send_debug(ssh, "Server has rejected tunnel device "
+ 		    "forwarding");
+ 		return NULL;

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-60000.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-60000.patch
@@ -1,0 +1,144 @@
+From f34d633f6fe6d6feb61c75a028a91178730a54fe Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Mon, 6 Jul 2026 07:53:30 +0000
+Subject: [PATCH] upstream: Fix multiple RFC 4462 (GSSAPIAuthentication)
+ compliance
+
+problems
+
+1) Remove an early failure return for GSSAPI authentication attempts
+made for invalid accounts that yielded different behaviour for
+valid vs invalid accounts.
+
+2) Fix a situation where some GSSAPI requestes were not correctly
+subjected to MaxAuthTries.
+
+3) Fix a moderate pre-authentication resource DoS related to #2.
+
+Add missing logging for error cases.
+
+Report and fixes from Manfred Kaiser, milCERT AT
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-connectivity/openssh/openssh/CVE-2026-60000.patch?h=scarthgap
+
+CVE: CVE-2026-60000
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/5d04ca6af739b82fd30d84d2783ca802ebfa1192]
+
+Backport Changes:
+- Kept Scarthgap's PRIVSEP(ssh_gssapi_server_ctx()) interface and its
+  authentication-context guard while applying the upstream RFC 4462 state,
+  failure, logging, and MaxAuthTries changes.
+- Retained the Scarthgap auth2-gss.c OpenBSD revision identifier.
+
+OpenBSD-Commit-ID: ca0acdd64eea435d6f89534538a9eb404a5629d3
+(cherry picked from commit 5d04ca6af739b82fd30d84d2783ca802ebfa1192)
+Signed-off-by: Devansh Patel <devanshp@cisco.com>
+[resolved merge conflict in auth2-gss.c while backporting to 8.2p1]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ auth2-gss.c | 53 ++++++++++++++++++++++++-----------------------------
+ 1 file changed, 24 insertions(+), 29 deletions(-)
+
+diff --git a/auth2-gss.c b/auth2-gss.c
+index 10a77e3ab..e39280836 100644
+--- a/auth2-gss.c
++++ b/auth2-gss.c
+@@ -103,12 +103,6 @@ userauth_gssapi(struct ssh *ssh)
+ 		return (0);
+ 	}
+ 
+-	if (!authctxt->valid || authctxt->user == NULL) {
+-		debug2("%s: disabled because of invalid user", __func__);
+-		free(doid);
+-		return (0);
+-	}
+-
+ 	if (GSS_ERROR(PRIVSEP(ssh_gssapi_server_ctx(&ctxt, &goid)))) {
+ 		if (ctxt != NULL)
+ 			ssh_gssapi_delete_ctx(&ctxt);
+@@ -170,8 +164,14 @@ input_gssapi_token(int type, u_int32_t plen, struct ssh *ssh)
+ 			    (r = sshpkt_send(ssh)) != 0)
+ 				fatal("%s: %s", __func__, ssh_err(r));
+ 		}
++		logit("Failed gssapi-with-mic for %s%.100s "
++		    "from %.200s port %d ssh2",
++		    authctxt->valid ? "" : "invalid user ",
++		    authctxt->user,
++		    ssh_remote_ipaddr(ssh), ssh_remote_port(ssh));
+ 		authctxt->postponed = 0;
+ 		ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_TOKEN, NULL);
++		ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_ERRTOK, NULL);
+ 		userauth_finish(ssh, 0, "gssapi-with-mic", NULL);
+ 	} else {
+ 		if (send_tok.length != 0) {
+@@ -183,14 +183,18 @@ input_gssapi_token(int type, u_int32_t plen, struct ssh *ssh)
+ 				fatal("%s: %s", __func__, ssh_err(r));
+ 		}
+ 		if (maj_status == GSS_S_COMPLETE) {
+-			ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_TOKEN, NULL);
+-			if (flags & GSS_C_INTEG_FLAG)
+-				ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_MIC,
++			ssh_dispatch_set(ssh,
++			    SSH2_MSG_USERAUTH_GSSAPI_TOKEN, NULL);
++			/* note: keep ERRTOK handler as per RFC 4462 s3.4 */
++			if (flags & GSS_C_INTEG_FLAG) {
++				ssh_dispatch_set(ssh,
++				    SSH2_MSG_USERAUTH_GSSAPI_MIC,
+ 				    &input_gssapi_mic);
+-			else
++			} else {
+ 				ssh_dispatch_set(ssh,
+ 				    SSH2_MSG_USERAUTH_GSSAPI_EXCHANGE_COMPLETE,
+ 				    &input_gssapi_exchange_complete);
++			}
+ 		}
+ 	}
+ 
+@@ -202,10 +206,6 @@ static int
+ input_gssapi_errtok(int type, u_int32_t plen, struct ssh *ssh)
+ {
+ 	Authctxt *authctxt = ssh->authctxt;
+-	Gssctxt *gssctxt;
+-	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
+-	gss_buffer_desc recv_tok;
+-	OM_uint32 maj_status;
+ 	int r;
+ 	u_char *p;
+ 	size_t len;
+@@ -213,26 +213,21 @@ input_gssapi_errtok(int type, u_int32_t plen, struct ssh *ssh)
+ 	if (authctxt == NULL || (authctxt->methoddata == NULL && !use_privsep))
+ 		fatal("No authentication or GSSAPI context");
+ 
+-	gssctxt = authctxt->methoddata;
+-	if ((r = sshpkt_get_string(ssh, &p, &len)) != 0 ||
++	/* Minimal error handling - just cancel auth and return FAILURE */
++	if ((r = sshpkt_get_string_direct(ssh, NULL, NULL)) != 0 ||
+ 	    (r = sshpkt_get_end(ssh)) != 0)
+ 		fatal("%s: %s", __func__, ssh_err(r));
+-	recv_tok.value = p;
+-	recv_tok.length = len;
+-
+-	/* Push the error token into GSSAPI to see what it says */
+-	maj_status = PRIVSEP(ssh_gssapi_accept_ctx(gssctxt, &recv_tok,
+-	    &send_tok, NULL));
+-
+-	free(recv_tok.value);
+ 
+-	/* We can't return anything to the client, even if we wanted to */
++	logit("Failed gssapi-with-mic for %s%.100s from %.200s port %d ssh2",
++	    authctxt->valid ? "" : "invalid user ",
++	    authctxt->user,
++	    ssh_remote_ipaddr(ssh), ssh_remote_port(ssh));
++	authctxt->postponed = 0;
+ 	ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_TOKEN, NULL);
+ 	ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_ERRTOK, NULL);
+-
+-	/* The client will have already moved on to the next auth */
+-
+-	gss_release_buffer(&maj_status, &send_tok);
++	ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_MIC, NULL);
++	ssh_dispatch_set(ssh, SSH2_MSG_USERAUTH_GSSAPI_EXCHANGE_COMPLETE, NULL);
++	userauth_finish(ssh, 0, "gssapi-with-mic", NULL);
+ 	return 0;
+ }
+ 

--- a/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-60001.patch
+++ b/meta-core/recipes-connectivity/openssh/openssh/CVE-2026-60001.patch
@@ -1,0 +1,133 @@
+From 769671be3b89082d15957d8a9e8447cd3d4f47dc Mon Sep 17 00:00:00 2001
+From: Andrej Koehler <akhldev@proton.me>
+Date: Tue, 11 Aug 2026 13:06:27 +0200
+Subject: [PATCH] upstream: Fix cases in GSSAPI and keyboard-interactive
+
+authentication where the minimum per-attempt delay was not being enforced.
+
+Reported by Orange Cyberdefense Vulnerability Team
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-connectivity/openssh/openssh/CVE-2026-60001.patch?h=scarthgap
+
+CVE: CVE-2026-60001
+Upstream-Status: Backport [https://github.com/openssh/openssh-portable/commit/d43ba60c91cb323ca921049b7d43b1908c318454]
+
+Backport Changes:
+- Kept Scarthgap's PRIVSEP(ssh_gssapi_userok()) interface and GSSAPI
+  display-name recording while adding the upstream failure-delay calls;
+  mm_ssh_gssapi_userok() belongs to the later split-sshd architecture.
+- Retained the Scarthgap OpenBSD revision identifiers in auth.h,
+  auth2-chall.c, auth2-gss.c, and auth2.c.
+
+OpenBSD-Commit-ID: c40bd35cc2428fcaccad7a141703c28baa6da01e
+(cherry picked from commit d43ba60c91cb323ca921049b7d43b1908c318454)
+Signed-off-by: Devansh Patel <devanshp@cisco.com>
+[manually applied the scarthgap patch file]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ auth.h        | 1 +
+ auth2-chall.c | 4 ++++
+ auth2-gss.c   | 7 +++++++
+ auth2.c       | 9 +++++++--
+ 4 files changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/auth.h b/auth.h
+index becc672b5..2e5f233c9 100644
+--- a/auth.h
++++ b/auth.h
+@@ -170,6 +170,7 @@ void	auth_log(struct ssh *, int, int, const char *, const char *);
+ void	auth_maxtries_exceeded(struct ssh *) __attribute__((noreturn));
+ void	userauth_finish(struct ssh *, int, const char *, const char *);
+ int	auth_root_allowed(struct ssh *, const char *);
++void	auth_failure_delay(Authctxt *, double);
+ 
+ char	*auth2_read_banner(void);
+ int	 auth2_methods_valid(const char *, int);
+diff --git a/auth2-chall.c b/auth2-chall.c
+index c57387b71..2354c56f6 100644
+--- a/auth2-chall.c
++++ b/auth2-chall.c
+@@ -298,6 +298,7 @@ input_userauth_info_response(int type, u_int32_t seq, struct ssh *ssh)
+ 	u_int i, nresp;
+ 	const char *devicename = NULL;
+ 	char **response = NULL;
++	double tstart = monotime_double();
+ 
+ 	if (authctxt == NULL)
+ 		fatal("input_userauth_info_response: no authctxt");
+@@ -356,6 +357,9 @@ input_userauth_info_response(int type, u_int32_t seq, struct ssh *ssh)
+ 			auth2_challenge_start(ssh);
+ 		}
+ 	}
++
++	if (!authenticated)
++		auth_failure_delay(authctxt, tstart);
+ 	userauth_finish(ssh, authenticated, "keyboard-interactive",
+ 	    devicename);
+ 	return 0;
+diff --git a/auth2-gss.c b/auth2-gss.c
+index 9351e0428..10a77e3ab 100644
+--- a/auth2-gss.c
++++ b/auth2-gss.c
+@@ -248,6 +248,7 @@ input_gssapi_exchange_complete(int type, u_int32_t plen, struct ssh *ssh)
+ 	Authctxt *authctxt = ssh->authctxt;
+ 	int r, authenticated;
+ 	const char *displayname;
++	double tstart = monotime_double();
+ 
+ 	if (authctxt == NULL || (authctxt->methoddata == NULL && !use_privsep))
+ 		fatal("No authentication or GSSAPI context");
+@@ -261,6 +262,8 @@ input_gssapi_exchange_complete(int type, u_int32_t plen, struct ssh *ssh)
+ 		fatal("%s: %s", __func__, ssh_err(r));
+ 
+ 	authenticated = PRIVSEP(ssh_gssapi_userok(authctxt->user));
++	if (!authenticated)
++		auth_failure_delay(authctxt, tstart);
+ 
+ 	if ((!use_privsep || mm_is_monitor()) &&
+ 	    (displayname = ssh_gssapi_displayname()) != NULL)
+@@ -286,6 +289,7 @@ input_gssapi_mic(int type, u_int32_t plen, struct ssh *ssh)
+ 	const char *displayname;
+ 	u_char *p;
+ 	size_t len;
++	double tstart = monotime_double();
+ 
+ 	if (authctxt == NULL || (authctxt->methoddata == NULL && !use_privsep))
+ 		fatal("No authentication or GSSAPI context");
+@@ -313,6 +317,9 @@ input_gssapi_mic(int type, u_int32_t plen, struct ssh *ssh)
+ 	sshbuf_free(b);
+ 	free(mic.value);
+ 
++	if (!authenticated)
++		auth_failure_delay(authctxt, tstart);
++
+ 	if ((!use_privsep || mm_is_monitor()) &&
+ 	    (displayname = ssh_gssapi_displayname()) != NULL)
+ 		auth2_record_info(authctxt, "%s", displayname);
+diff --git a/auth2.c b/auth2.c
+index 0e7762242..c75e5c082 100644
+--- a/auth2.c
++++ b/auth2.c
+@@ -257,6 +257,12 @@ ensure_minimum_time_since(double start, double seconds)
+ 	nanosleep(&ts, NULL);
+ }
+ 
++void
++auth_failure_delay(Authctxt *authctxt, double tstart)
++{
++	ensure_minimum_time_since(tstart, user_specific_delay(authctxt->user));
++}
++
+ /*ARGSUSED*/
+ static int
+ input_userauth_request(int type, u_int32_t seq, struct ssh *ssh)
+@@ -337,8 +343,7 @@ input_userauth_request(int type, u_int32_t seq, struct ssh *ssh)
+ 		authenticated =	m->userauth(ssh);
+ 	}
+ 	if (!authctxt->authenticated)
+-		ensure_minimum_time_since(tstart,
+-		    user_specific_delay(authctxt->user));
++		auth_failure_delay(authctxt, tstart);
+ 	userauth_finish(ssh, authenticated, method, NULL);
+ 	r = 0;
+  out:

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -36,3 +36,9 @@ CVE_CHECK_WHITELIST += "${@bb.utils.contains('PACKAGECONFIG', 'kerberos', '', 'C
 # Debian treats this CVE as minor and does not provide fixes.
 # https://security-tracker.debian.org/tracker/CVE-2026-59996
 CVE_CHECK_WHITELIST += "CVE-2026-59996"
+
+# https://nvd.nist.gov/vuln/detail/CVE-2026-60002
+# The affected code is quite different in OpenSSH 8.2p1 and the upstream fix is not applicable.
+# Debian treats this CVE as minor and does not provide fixes.
+# https://security-tracker.debian.org/tracker/CVE-2026-60002
+CVE_CHECK_WHITELIST += "CVE-2026-60002"

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -21,3 +21,7 @@ SRC_URI_append = " \
 # does not intent to address it in OpenSSH
 # https://security-tracker.debian.org/tracker/CVE-2023-51767
 CVE_CHECK_WHITELIST += "CVE-2023-51767"
+
+# https://nvd.nist.gov/vuln/detail/CVE-2026-3497
+# not-applicable-platform: Only affects GSSAPI Key Exchange patches used by some Linux distributions and does not exist in upstream openssh.
+CVE_CHECK_WHITELIST += "CVE-2026-3497"

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -13,6 +13,7 @@ SRC_URI_append = " \
     file://CVE-2026-59999.patch \
     file://CVE-2026-59997.patch \
     file://CVE-2026-59995.patch \
+    file://CVE-2026-60001.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -14,6 +14,7 @@ SRC_URI_append = " \
     file://CVE-2026-59997.patch \
     file://CVE-2026-59995.patch \
     file://CVE-2026-60001.patch \
+    file://CVE-2026-60000.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -11,6 +11,7 @@ SRC_URI_append = " \
     file://CVE-2026-35388.patch \
     file://CVE-2026-35414.patch \
     file://CVE-2026-59999.patch \
+    file://CVE-2026-59997.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -9,6 +9,7 @@ SRC_URI_append = " \
     file://CVE-2026-35386-01.patch \
     file://CVE-2026-35386-02.patch \
     file://CVE-2026-35388.patch \
+    file://CVE-2026-35414.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -10,6 +10,7 @@ SRC_URI_append = " \
     file://CVE-2026-35386-02.patch \
     file://CVE-2026-35388.patch \
     file://CVE-2026-35414.patch \
+    file://CVE-2026-59999.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -25,3 +25,8 @@ CVE_CHECK_WHITELIST += "CVE-2023-51767"
 # https://nvd.nist.gov/vuln/detail/CVE-2026-3497
 # not-applicable-platform: Only affects GSSAPI Key Exchange patches used by some Linux distributions and does not exist in upstream openssh.
 CVE_CHECK_WHITELIST += "CVE-2026-3497"
+
+# https://nvd.nist.gov/vuln/detail/CVE-2026-59998
+# Only relevant when Kerberos support is disabled.
+# not-applicable-config: GSSAPI/Kerberos support is disabled in the default OpenSSH configuration
+CVE_CHECK_WHITELIST += "${@bb.utils.contains('PACKAGECONFIG', 'kerberos', '', 'CVE-2026-59998', d)}"

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -30,3 +30,9 @@ CVE_CHECK_WHITELIST += "CVE-2026-3497"
 # Only relevant when Kerberos support is disabled.
 # not-applicable-config: GSSAPI/Kerberos support is disabled in the default OpenSSH configuration
 CVE_CHECK_WHITELIST += "${@bb.utils.contains('PACKAGECONFIG', 'kerberos', '', 'CVE-2026-59998', d)}"
+
+# https://nvd.nist.gov/vuln/detail/CVE-2026-59996
+# The affected function does not exist in OpenSSH 8.2p1
+# Debian treats this CVE as minor and does not provide fixes.
+# https://security-tracker.debian.org/tracker/CVE-2026-59996
+CVE_CHECK_WHITELIST += "CVE-2026-59996"

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -12,6 +12,7 @@ SRC_URI_append = " \
     file://CVE-2026-35414.patch \
     file://CVE-2026-59999.patch \
     file://CVE-2026-59997.patch \
+    file://CVE-2026-59995.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and

--- a/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
+++ b/meta-core/recipes-connectivity/openssh/openssh_8.2p1.bbappend
@@ -8,6 +8,7 @@ SRC_URI_append = " \
     file://CVE-2026-35387.patch \
     file://CVE-2026-35386-01.patch \
     file://CVE-2026-35386-02.patch \
+    file://CVE-2026-35388.patch \
     "
 
 # Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and


### PR DESCRIPTION
Migrated several CVE patch files from scarthgap for openssh.

Most of the patch files apply cleanly. Two patches can not be applied, the code is too different.
Added them to the whitelist since they are minor.

Verification: Compiles, openssh ptests local run PASS