### PR TITLE
zlib: Add CVE_PRODUCT to exclude false positives (kirkstone)

### DIFF
--- a/meta-core/recipes-core/zlib/zlib_1.2.11.bbappend
+++ b/meta-core/recipes-core/zlib/zlib_1.2.11.bbappend
@@ -1,0 +1,2 @@
+# Adding 'CVE_PRODUCT' to avoid false detection of CVEs
+CVE_PRODUCT = "zlib:zlib gnu:zlib"


### PR DESCRIPTION
Backports CVE_PRODUCT for zlib from upstream to avoid false positives such as CVE-2023-6992, CVE-2026-27820.

Upstream: [https://github.com/openembedded/openembedded-core/commit/119b775b36dfd51286493763cffb6e965893b8fd]

verified with cve_check, CVE-2026-27820 does not show up anymore for zlib