### PR TITLE
libarchive: Fix CVE-2026-4424

### DIFF
--- a/meta-core/recipes-extended/libarchive/libarchive/CVE-2026-4424-0001.patch
+++ b/meta-core/recipes-extended/libarchive/libarchive/CVE-2026-4424-0001.patch
@@ -1,0 +1,58 @@
+From d379dc0b2976b7207d1ad78f5ed3eb99a5b6d375 Mon Sep 17 00:00:00 2001
+From: elhananhaenel <elhanan.haenel@mail.huji.ac.il>
+Date: Sat, 7 Mar 2026 22:32:09 +0200
+Subject: [PATCH] rar: fix LZSS window size mismatch after PPMd block
+
+When a PPMd-compressed block updates dictionary_size, the LZSS window
+from a prior block is not reallocated. The allocation guard only checks
+if dictionary_size is zero or the window pointer is NULL, not whether
+the existing window is large enough. This allows copy_from_lzss_window()
+to read past the allocated buffer.
+
+Fix the guard to also check whether the current window is undersized.
+Add bounds checks in copy_from_lzss_window() and parse_filter() as
+defense in depth.
+
+CVE: CVE-2026-4424
+Upstream-Status: Backport [https://github.com/libarchive/libarchive/commit/d379dc0b2976b7207d1ad78f5ed3eb99a5b6d375]
+Signed-off-by: Zach Malinowski <zach.malinowski@protonmail.com>
+---
+ libarchive/archive_read_support_format_rar.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/libarchive/archive_read_support_format_rar.c b/libarchive/archive_read_support_format_rar.c
+index 9b401c00ba..08e407f9d8 100644
+--- a/libarchive/archive_read_support_format_rar.c
++++ b/libarchive/archive_read_support_format_rar.c
+@@ -2548,7 +2548,8 @@ parse_codes(struct archive_read *a)
+       return (r);
+   }
+
+-  if (!rar->dictionary_size || !rar->lzss.window)
++  if (!rar->dictionary_size || !rar->lzss.window ||
++      (rar->lzss.mask + 1) < rar->dictionary_size)
+   {
+     /* Seems as though dictionary sizes are not used. Even so, minimize
+      * memory usage as much as possible.
+@@ -3149,6 +3150,11 @@ copy_from_lzss_window(struct archive_read *a, uint8_t *buffer,
+
+   windowoffs = lzss_offset_for_position(&rar->lzss, startpos);
+   firstpart = lzss_size(&rar->lzss) - windowoffs;
++  if (length > lzss_size(&rar->lzss)) {
++    archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
++                      "Bad RAR file data");
++    return (ARCHIVE_FATAL);
++  }
+   if (firstpart < 0) {
+     archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+                       "Bad RAR file data");
+@@ -3315,7 +3321,8 @@ parse_filter(struct archive_read *a, const uint8_t *bytes, uint16_t length, uint
+   else
+     blocklength = prog ? prog->oldfilterlength : 0;
+
+-  if (blocklength > rar->dictionary_size)
++  if (blocklength > rar->dictionary_size ||
++      blocklength > (uint32_t)(rar->lzss.mask + 1))
+     return 0;
+
+   registers[3] = PROGRAM_SYSTEM_GLOBAL_ADDRESS;

--- a/meta-core/recipes-extended/libarchive/libarchive/CVE-2026-4424-0002.patch
+++ b/meta-core/recipes-extended/libarchive/libarchive/CVE-2026-4424-0002.patch
@@ -1,0 +1,25 @@
+From e1907c5832b6489c7b4198b0825f857c93a03c10 Mon Sep 17 00:00:00 2001
+From: elhananhaenel <elhanan.haenel@mail.huji.ac.il>
+Date: Sun, 8 Mar 2026 15:29:46 +0200
+Subject: [PATCH] Fix -Wsign-compare: cast mask+1 to unsigned int
+
+CVE: CVE-2026-4424
+Upstream-Status: Backport [https://github.com/libarchive/libarchive/commit/e1907c5832b6489c7b4198b0825f857c93a03c10]
+Signed-off-by: Zach Malinowski <zach.malinowski@protonmail.com>
+---
+ libarchive/archive_read_support_format_rar.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libarchive/archive_read_support_format_rar.c b/libarchive/archive_read_support_format_rar.c
+index 08e407f9d8..497676ddf0 100644
+--- a/libarchive/archive_read_support_format_rar.c
++++ b/libarchive/archive_read_support_format_rar.c
+@@ -2549,7 +2549,7 @@ parse_codes(struct archive_read *a)
+   }
+
+   if (!rar->dictionary_size || !rar->lzss.window ||
+-      (rar->lzss.mask + 1) < rar->dictionary_size)
++      (unsigned int)(rar->lzss.mask + 1) < rar->dictionary_size)
+   {
+     /* Seems as though dictionary sizes are not used. Even so, minimize
+      * memory usage as much as possible.

--- a/meta-core/recipes-extended/libarchive/libarchive_3.6.2.bbappend
+++ b/meta-core/recipes-extended/libarchive/libarchive_3.6.2.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += "\
+    file://CVE-2026-4424-0001.patch \
+    file://CVE-2026-4424-0002.patch \
+    "


### PR DESCRIPTION
Backport patch to fix CVE-2026-4424.

References:
  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-4424
  https://nvd.nist.gov/vuln/detail/CVE-2026-4424

Upstream fix:
  https://github.com/libarchive/libarchive/pull/2898

Signed-off-by: Zach Malinowski <zach.malinowski@protonmail.com>