### PR TITLE
ci: fix periodic caching (Kirkstone)

### DIFF
--- a/.github/workflows/_periodic.yml
+++ b/.github/workflows/_periodic.yml
@@ -9,6 +9,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: 'core-image-minimal'
         type: string
+      use-cache:
+        description: 'If "true", restore downloads and sstate before the build'
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -39,7 +44,7 @@ jobs:
       only-build-modified: false
       run-tests: true
       target-image: ${{ inputs.target-image }}
-      use-cache: false
+      use-cache: ${{ inputs.use-cache }}
       use-systemd: ${{ matrix.systemd }}
 
   cve-check:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@
 name: Nightly
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: "0 3 * * * 1-6"
+    - cron: "0 3 * * 1-6"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -13,3 +13,4 @@ jobs:
     uses: ./.github/workflows/_periodic.yml
     with:
       target-image: core-image-ptest-all
+      use-cache: false


### PR DESCRIPTION
Ensures the weekly job does not use an existing cache, while the nightly job will use an existing cache.