### PR TITLE
core: expat: Fix for CVE-2026-25210

### DIFF
--- a/meta-core/recipes-core/expat/expat/CVE-2026-25210-01.patch
+++ b/meta-core/recipes-core/expat/expat/CVE-2026-25210-01.patch
@@ -1,0 +1,28 @@
+From 7ddea353ad3795f7222441274d4d9a155b523cba Mon Sep 17 00:00:00 2001
+From: Matthew Fernandez <matthew.fernandez@gmail.com>
+Date: Thu, 2 Oct 2025 17:15:15 -0700
+Subject: [PATCH] lib: Make a doubling more readable
+
+Suggested-by: Sebastian Pipping <sebastian@pipping.org>
+
+CVE: CVE-2026-25210
+Upstream-Status: Backport [https://github.com/libexpat/libexpat/commit/7ddea353ad3795f7222441274d4d9a155b523cba]
+Signed-off-by: Peter Marko <peter.marko@siemens.com>
+Signed-off-by: Mohammed Faizan <mfaiz1804@gmail.com>
+---
+ lib/xmlparse.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/xmlparse.c b/lib/xmlparse.c
+index 8cf29257..2f9adffc 100644
+--- a/lib/xmlparse.c
++++ b/lib/xmlparse.c
+@@ -2921,7 +2921,7 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
+             tag->name.strLen = convLen;
+             break;
+           }
+-          bufSize = (int)(tag->bufEnd - tag->buf) << 1;
++          bufSize = (int)(tag->bufEnd - tag->buf) * 2;
+           {
+             char *temp = (char *)REALLOC(parser, tag->buf, bufSize);
+             if (temp == NULL)

--- a/meta-core/recipes-core/expat/expat/CVE-2026-25210-02.patch
+++ b/meta-core/recipes-core/expat/expat/CVE-2026-25210-02.patch
@@ -1,0 +1,38 @@
+From 8855346359a475c022ec8c28484a76c852f144d9 Mon Sep 17 00:00:00 2001
+From: Matthew Fernandez <matthew.fernandez@gmail.com>
+Date: Thu, 2 Oct 2025 17:15:15 -0700
+Subject: [PATCH] lib: Realign a size with the `REALLOC` type signature it is
+ passed into
+
+Note that this implicitly assumes `tag->bufEnd >= tag->buf`, which should
+already be guaranteed true.
+
+CVE: CVE-2026-25210
+Upstream-Status: Backport [https://github.com/libexpat/libexpat/commit/8855346359a475c022ec8c28484a76c852f144d9]
+Signed-off-by: Peter Marko <peter.marko@siemens.com>
+Signed-off-by: Mohammed Faizan <mfaiz1804@gmail.com>
+---
+ lib/xmlparse.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/lib/xmlparse.c b/lib/xmlparse.c
+index 2f9adffc..ee18a87f 100644
+--- a/lib/xmlparse.c
++++ b/lib/xmlparse.c
+@@ -2910,7 +2910,6 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
+         const char *fromPtr = tag->rawName;
+         toPtr = (XML_Char *)tag->buf;
+         for (;;) {
+-          int bufSize;
+           int convLen;
+           const enum XML_Convert_Result convert_res
+               = XmlConvert(enc, &fromPtr, rawNameEnd, (ICHAR **)&toPtr,
+@@ -2921,7 +2920,7 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
+             tag->name.strLen = convLen;
+             break;
+           }
+-          bufSize = (int)(tag->bufEnd - tag->buf) * 2;
++          const size_t bufSize = (size_t)(tag->bufEnd - tag->buf) * 2;
+           {
+             char *temp = (char *)REALLOC(parser, tag->buf, bufSize);
+             if (temp == NULL)

--- a/meta-core/recipes-core/expat/expat/CVE-2026-25210-03.patch
+++ b/meta-core/recipes-core/expat/expat/CVE-2026-25210-03.patch
@@ -1,0 +1,29 @@
+From 9c2d990389e6abe2e44527eeaa8b39f16fe859c7 Mon Sep 17 00:00:00 2001
+From: Matthew Fernandez <matthew.fernandez@gmail.com>
+Date: Thu, 2 Oct 2025 17:15:15 -0700
+Subject: [PATCH] lib: Introduce an integer overflow check for tag buffer
+ reallocation
+
+Suggested-by: Sebastian Pipping <sebastian@pipping.org>
+
+CVE: CVE-2026-25210
+Upstream-Status: Backport [https://github.com/libexpat/libexpat/commit/9c2d990389e6abe2e44527eeaa8b39f16fe859c7]
+Signed-off-by: Peter Marko <peter.marko@siemens.com>
+Signed-off-by: Mohammed Faizan <mfaiz1804@gmail.com>
+---
+ lib/xmlparse.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/xmlparse.c b/lib/xmlparse.c
+index ee18a87f..d8c54c38 100644
+--- a/lib/xmlparse.c
++++ b/lib/xmlparse.c
+@@ -2920,6 +2920,8 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
+             tag->name.strLen = convLen;
+             break;
+           }
++          if (SIZE_MAX / 2 < (size_t)(tag->bufEnd - tag->buf))
++            return XML_ERROR_NO_MEMORY;
+           const size_t bufSize = (size_t)(tag->bufEnd - tag->buf) * 2;
+           {
+             char *temp = (char *)REALLOC(parser, tag->buf, bufSize);

--- a/meta-core/recipes-core/expat/expat_2.2.9.bbappend
+++ b/meta-core/recipes-core/expat/expat_2.2.9.bbappend
@@ -8,4 +8,7 @@ SRC_URI_append = " \
     file://CVE-2024-50602-01.patch \
     file://CVE-2024-50602-02.patch \
     file://CVE-2026-24515.patch \
+    file://CVE-2026-25210-01.patch \
+    file://CVE-2026-25210-02.patch \
+    file://CVE-2026-25210-03.patch \
     "


### PR DESCRIPTION
Backports the patches for CVE-2026-25210