### PR TITLE
Fix caching (Kirkstone)

### DIFF
--- a/.github/workflows/_bitbake.yml
+++ b/.github/workflows/_bitbake.yml
@@ -31,11 +31,6 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
-      use-cache:
-        description: 'If "true", restore downloads and sstate before the build'
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: read
@@ -71,7 +66,7 @@ jobs:
           append: 'true'
 
       - name: Restore downloads and sstate
-        if: ${{ inputs.use-cache && steps.targets.outputs.all_build_targets != '' }}
+        if: ${{ steps.targets.outputs.all_build_targets != '' }}
         uses: ./.github/actions/restore-build-cache
         with:
           branch: ${{ inputs.branch }}

--- a/.github/workflows/_bitbake.yml
+++ b/.github/workflows/_bitbake.yml
@@ -74,11 +74,24 @@ jobs:
           systemd: ${{ inputs.use-systemd }}
 
       - name: bitbake ${{ inputs.target-image }}
+        id: bitbake
         if: ${{ steps.targets.outputs.all_build_targets != '' }}
         working-directory: ${{ github.workspace }}
         run: |
           source poky/oe-init-build-env
           bitbake ${{ inputs.target-image }} ${{ steps.targets.outputs.native_targets }}
+
+      - name: Save downloads and sstate
+        if: ${{ steps.targets.outputs.all_build_targets != '' && !contains('skipped,cancelled', steps.bitbake.outcome) && always() }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ${{ github.workspace }}/build/downloads
+            ${{ github.workspace }}/build/sstate-cache
+          key:
+            "downloads-and-sstate-${{ inputs.branch }}-\
+            ${{ inputs.use-systemd && 'systemd' || 'sysvinit' }}-\
+            ${{ github.run_id }}-${{ github.run_attempt }}"
 
       - name: Enable KVM permissions
         if: ${{ inputs.run-tests && steps.targets.outputs.image_targets != '' }}
@@ -94,15 +107,3 @@ jobs:
         run: |
           source poky/oe-init-build-env
           bitbake -c testimage ${{ inputs.target-image }}
-
-      - name: Save downloads and sstate
-        if: ${{ always() && steps.targets.outputs.all_build_targets != '' }}
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: |
-            ${{ github.workspace }}/build/downloads
-            ${{ github.workspace }}/build/sstate-cache
-          key:
-            "downloads-and-sstate-${{ inputs.branch }}-\
-            ${{ inputs.use-systemd && 'systemd' || 'sysvinit' }}-\
-            ${{ github.run_id }}-${{ github.run_attempt }}"

--- a/.github/workflows/_common.yml
+++ b/.github/workflows/_common.yml
@@ -19,11 +19,6 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: 'core-image-minimal'
         type: string
-      use-cache:
-        description: 'If "true", restore downloads and sstate before the build'
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: read
@@ -54,5 +49,4 @@ jobs:
       only-build-modified: ${{ inputs.only-build-modified }}
       run-tests: ${{ inputs.run-tests }}
       target-image: ${{ inputs.target-image }}
-      use-cache: ${{ inputs.use-cache }}
       use-systemd: ${{ matrix.systemd }}

--- a/.github/workflows/_cve-check.yml
+++ b/.github/workflows/_cve-check.yml
@@ -47,10 +47,22 @@ jobs:
           append: 'true'
 
       - name: bitbake cve_check universe
+        id: bitbake
         working-directory: ${{ github.workspace }}
         run: |
           source poky/oe-init-build-env
           bitbake -k -c cve_check universe
+
+      - name: Save downloads and sstate
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        if: ${{ !contains('skipped,cancelled', steps.bitbake.outcome) && always() }}
+        with:
+          path: |
+            ${{ github.workspace }}/build/downloads
+            ${{ github.workspace }}/build/sstate-cache
+          key:
+            "downloads-and-sstate-${{ inputs.branch }}-\
+            sysvinit-${{ github.run_id }}-${{ github.run_attempt }}"
 
       - name: Stage cve-summary
         run: |
@@ -65,14 +77,3 @@ jobs:
           name: cve-summary-${{ inputs.branch }}
           path: ${{ github.workspace }}/cve-output/${{ inputs.branch }}-cve-summary.json
           retention-days: 2
-
-      - name: Save downloads and sstate
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        if: always()
-        with:
-          path: |
-            ${{ github.workspace }}/build/downloads
-            ${{ github.workspace }}/build/sstate-cache
-          key:
-            "downloads-and-sstate-${{ inputs.branch }}-\
-            sysvinit-${{ github.run_id }}-${{ github.run_attempt }}"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,7 +16,6 @@ jobs:
     uses: ./.github/workflows/_common.yml
     with:
       target-image: core-image-ptest-all
-      use-cache: false
 
   update-cve-dashboard:
     uses: ./.github/workflows/_update-cve-dashboard.yml


### PR DESCRIPTION
After the weekly action failed, I want to introduce two tweaks with caching:
- Always use the cache
- Only save caches when bitable runs and succeeds for fails

This should ensure the weekly job gets a download and sstate cache. If this causes caches to become too large over time, they can be manually deleted and we can re-evaluate options.

I have also seen some caches that seem to be mostly empty. I'd like to ensure that the cache will only be saved if bitbake runs and either succeeds or fails. If the job is skipped or cancelled, the cache will not be saved.