### PR TITLE
ci: Backport kirkstone updates (Dunfell)

### DIFF
--- a/.github/workflows/_bitbake.yml
+++ b/.github/workflows/_bitbake.yml
@@ -31,11 +31,6 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
-      use-cache:
-        description: 'If "true", restore downloads and sstate before the build'
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: read
@@ -71,7 +66,7 @@ jobs:
           append: 'true'
 
       - name: Restore downloads and sstate
-        if: ${{ inputs.use-cache && steps.targets.outputs.all_build_targets != '' }}
+        if: ${{ steps.targets.outputs.all_build_targets != '' }}
         uses: ./.github/actions/restore-build-cache
         with:
           branch: ${{ inputs.branch }}
@@ -79,12 +74,25 @@ jobs:
           systemd: ${{ inputs.use-systemd }}
 
       - name: bitbake ${{ inputs.target-image }}
+        id: bitbake
         if: ${{ steps.targets.outputs.all_build_targets != '' }}
         working-directory: ${{ github.workspace }}
         run: |
           source "$GITHUB_WORKSPACE/buildtools/environment-setup-x86_64-pokysdk-linux"
           source poky/oe-init-build-env
           bitbake ${{ inputs.target-image }} ${{ steps.targets.outputs.native_targets }}
+
+      - name: Save downloads and sstate
+        if: ${{ steps.targets.outputs.all_build_targets != '' && !contains('skipped,cancelled', steps.bitbake.outcome) && always() }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ${{ github.workspace }}/build/downloads
+            ${{ github.workspace }}/build/sstate-cache
+          key:
+            "downloads-and-sstate-${{ inputs.branch }}-\
+            ${{ inputs.use-systemd && 'systemd' || 'sysvinit' }}-\
+            ${{ github.run_id }}-${{ github.run_attempt }}"
 
       - name: Enable KVM permissions
         if: ${{ inputs.run-tests && steps.targets.outputs.image_targets != '' }}
@@ -101,15 +109,3 @@ jobs:
           source "$GITHUB_WORKSPACE/buildtools/environment-setup-x86_64-pokysdk-linux"
           source poky/oe-init-build-env
           bitbake -c testimage ${{ inputs.target-image }}
-
-      - name: Save downloads and sstate
-        if: ${{ always() && steps.targets.outputs.all_build_targets != '' }}
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: |
-            ${{ github.workspace }}/build/downloads
-            ${{ github.workspace }}/build/sstate-cache
-          key:
-            "downloads-and-sstate-${{ inputs.branch }}-\
-            ${{ inputs.use-systemd && 'systemd' || 'sysvinit' }}-\
-            ${{ github.run_id }}-${{ github.run_attempt }}"

--- a/.github/workflows/_common.yml
+++ b/.github/workflows/_common.yml
@@ -1,0 +1,52 @@
+---
+# Reusable workflow: Shared workflow for all jobs
+name: '[Reusable] Common jobs'
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      run-tests:
+        description: 'If "true", run testimage after the build'
+        required: false
+        default: true
+        type: boolean
+      only-build-modified:
+        description: 'If "true", only build recipes that have changed'
+        required: false
+        default: false
+        type: boolean
+      target-image:
+        description: 'The image that is intended to be built'
+        required: false
+        default: 'core-image-minimal'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/_lint.yml
+
+  check-layer:
+    name: Check layer
+    needs: lint
+    uses: ./.github/workflows/_yocto-check-layer.yml
+    with:
+      branch: dunfell
+      runner: ubuntu-22.04
+
+  build:
+    name: 'Build (systemd=${{ matrix.systemd }})'
+    needs: check-layer
+    strategy:
+      matrix:
+        systemd: [true, false]
+    uses: ./.github/workflows/_bitbake.yml
+    with:
+      branch: dunfell
+      runner: yocto_build_host
+      only-build-modified: ${{ inputs.only-build-modified }}
+      run-tests: ${{ inputs.run-tests }}
+      target-image: ${{ inputs.target-image }}
+      use-systemd: ${{ matrix.systemd }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,9 @@
 ---
-name: Push
+name: Nightly
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches: ["dunfell"]
+  schedule:
+    - cron: "0 3 * * 1-6"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,4 +15,4 @@ jobs:
     name: "Common"
     uses: ./.github/workflows/_common.yml
     with:
-      run-tests: false
+      target-image: core-image-ptest-fast

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,35 +8,15 @@ permissions:
   contents: read
 
 jobs:
-  lint:
-    name: Lint
-    uses: ./.github/workflows/_lint.yml
-
-  check-layer:
-    name: Check layer
-    needs: lint
-    uses: ./.github/workflows/_yocto-check-layer.yml
+  common:
+    name: "Common"
+    uses: ./.github/workflows/_common.yml
     with:
-      branch: ${{ github.base_ref }}
-      runner: ubuntu-22.04
-
-  build:
-    name: 'Build (systemd=${{ matrix.systemd }})'
-    needs: check-layer
-    strategy:
-      matrix:
-        systemd: [true, false]
-    uses: ./.github/workflows/_bitbake.yml
-    with:
-      branch: ${{ github.base_ref }}
-      runner: yocto_build_host
       only-build-modified: true
-      run-tests: true
-      use-systemd: ${{ matrix.systemd }}
 
   validate-pr-status:
     name: Required checks pass
-    needs: [lint, check-layer, build]
+    needs: common
     if: always()
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -2,36 +2,17 @@
 name: Weekly
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: "0 3 * * SUN"
+    - cron: "0 3 * * 0"
   workflow_dispatch:
 
 permissions:
   contents: read
+  id-token: write
+  pages: write
 
 jobs:
-  lint:
-    name: Lint
-    uses: ./.github/workflows/_lint.yml
-
-  check-layer:
-    name: Check layer
-    needs: lint
-    uses: ./.github/workflows/_yocto-check-layer.yml
+  common:
+    name: "Common"
+    uses: ./.github/workflows/_common.yml
     with:
-      branch: dunfell
-      runner: ubuntu-22.04
-
-  build:
-    name: 'Build (systemd=${{ matrix.systemd }})'
-    needs: check-layer
-    strategy:
-      matrix:
-        systemd: [true, false]
-    uses: ./.github/workflows/_bitbake.yml
-    with:
-      branch: dunfell
-      runner: yocto_build_host
-      only-build-modified: false
-      run-tests: ${{ github.event_name == 'schedule' }}
-      use-cache: false
-      use-systemd: ${{ matrix.systemd }}
+      target-image: core-image-ptest-all


### PR DESCRIPTION
Backports changes from the Kirkstone branch to optimize the CI configuration, add nightly & weekly tests, and update caching to always be used and correctly saved.