### PR TITLE
jq: Fix CVE-2026-39979

### DIFF
--- a/meta-oe/recipes-devtools/jq/jq/CVE-2026-39979.patch
+++ b/meta-oe/recipes-devtools/jq/jq/CVE-2026-39979.patch
@@ -1,0 +1,28 @@
+From: =?utf-8?b?IkNoYW5nWmh1byBDaGVuICjpmbPmmIzlgKwpIg==?=
+ <czchen@debian.org>
+Date: Fri, 17 Apr 2026 09:07:31 +0800
+Subject: CVE-2026-39979
+
+CVE: CVE-2026-39979
+Upstream-Status: Submitted [https://github.com/jqlang/jq/commit/2f09060afab23fe9390cce7cb860b10416e1bf5f]
+Origin: Backport [https://salsa.debian.org/debian/jq/-/blob/debian/bookworm-backports/debian/patches/CVE-2026-39979.patch]
+Signed-off-by: Zach Malinowski <zach.malinowski@protonmail.com>
+---
+ src/jv_parse.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/jv_parse.c b/src/jv_parse.c
+index ffcf51f..e6b8aa9 100644
+--- a/src/jv_parse.c
++++ b/src/jv_parse.c
+@@ -892,8 +892,9 @@ jv jv_parse_sized_custom_flags(const char* string, int length, int flags) {
+
+   if (!jv_is_valid(value) && jv_invalid_has_msg(jv_copy(value))) {
+     jv msg = jv_invalid_get_msg(value);
+-    value = jv_invalid_with_msg(jv_string_fmt("%s (while parsing '%s')",
++    value = jv_invalid_with_msg(jv_string_fmt("%s (while parsing '%.*s')",
+                                               jv_string_value(msg),
++                                              length,
+                                               string));
+     jv_free(msg);
+   }

--- a/meta-oe/recipes-devtools/jq/jq_1.6.bbappend
+++ b/meta-oe/recipes-devtools/jq/jq_1.6.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI_append = " \
     file://CVE-2024-23337.patch \
     file://CVE-2025-48060.patch \
+    file://CVE-2026-39979.patch \
     "
 
 # fixed-version: Does not affect jq 1.6.


### PR DESCRIPTION
Backport patch to fix CVE-2026-39979 in jq 1.6.

References:
  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-39979

CVE: CVE-2026-39979
Upstream-Status: upstream [https://github.com/jqlang/jq/commit/2f09060afab23fe9390cce7cb860b10416e1bf5f]
Origin: Backport [https://salsa.debian.org/debian/jq/-/blob/debian/bookworm-backports/debian/patches/CVE-2026-39979.patch]