### PR TITLE
python3: Fix CVE-2025-13462

### DIFF
--- a/meta-core/recipes-devtools/python/python3/CVE-2025-13462-0001.patch
+++ b/meta-core/recipes-devtools/python/python3/CVE-2025-13462-0001.patch
@@ -1,0 +1,147 @@
+From 162b8118e311a8e068ba387ecce5ebe6e2792590 Mon Sep 17 00:00:00 2001
+From: "Miss Islington (bot)"
+ <31488909+miss-islington@users.noreply.github.com>
+Date: Thu, 30 Apr 2026 23:18:52 +0200
+Subject: [PATCH 1/2] gh-141707: Skip TarInfo DIRTYPE normalization during GNU
+ long name handling (#145816)
+
+gh-141707: Skip TarInfo DIRTYPE normalization during GNU long name handling
+(cherry picked from commit 42d754e34c06e57ad6b8e7f92f32af679912d8ab)
+
+The debian patch was split into 2 parts to fit Python 3.8. This is part 1.
+
+Co-authored-by: Seth Michael Larson <seth@python.org>
+Co-authored-by: Eashwar Ranganathan <eashwar@eashwar.com>
+CVE: CVE-2025-13462
+Upstream-Status: Submitted [https://github.com/python/cpython/commit/72dde1016493c52abe857fc4a7bf6c40138b4114]
+Origin: Backport [https://salsa.debian.org/lts-team/packages/python3.9/-/blob/debian/bullseye/debian/patches/CVE-2025-13462.patch]
+Signed-off-by: Zach Malinowski <zach.malinowski@protonmail.com>
+---
+ Lib/tarfile.py                                | 29 ++++++++++++++++---
+ Lib/test/test_tarfile.py                      | 19 ++++++++++++
+ Misc/ACKS                                     |  1 +
+ ...-11-18-06-35-53.gh-issue-141707.DBmQIy.rst |  2 ++
+ 4 files changed, 47 insertions(+), 4 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Library/2025-11-18-06-35-53.gh-issue-141707.DBmQIy.rst
+
+diff --git a/Lib/tarfile.py b/Lib/tarfile.py
+index 775d27e..e64ba08 100755
+--- a/Lib/tarfile.py
++++ b/Lib/tarfile.py
+@@ -1217,6 +1217,20 @@ class TarInfo(object):
+     @classmethod
+     def frombuf(cls, buf, encoding, errors):
+         """Construct a TarInfo object from a 512 byte bytes object.
++
++        To support the old v7 tar format AREGTYPE headers are
++        transformed to DIRTYPE headers if their name ends in '/'.
++        """
++        return cls._frombuf(buf, encoding, errors)
++
++    @classmethod
++    def _frombuf(cls, buf, encoding, errors, *, dircheck=True):
++        """Construct a TarInfo object from a 512 byte bytes object.
++
++        If ``dircheck`` is set to ``True`` then ``AREGTYPE`` headers will
++        be normalized to ``DIRTYPE`` if the name ends in a trailing slash.
++        ``dircheck`` must be set to ``False`` if this function is called
++        on a follow-up header such as ``GNUTYPE_LONGNAME``.
+         """
+         if len(buf) == 0:
+             raise EmptyHeaderError("empty header")
+@@ -1247,7 +1261,7 @@ class TarInfo(object):
+
+         # Old V7 tar format represents a directory as a regular
+         # file with a trailing slash.
+-        if obj.type == AREGTYPE and obj.name.endswith("/"):
++        if dircheck and obj.type == AREGTYPE and obj.name.endswith("/"):
+             obj.type = DIRTYPE
+
+         # The old GNU sparse format occupies some of the unused
+@@ -1282,8 +1296,15 @@ class TarInfo(object):
+         """Return the next TarInfo object from TarFile object
+            tarfile.
+         """
++        return cls._fromtarfile(tarfile)
++
++    @classmethod
++    def _fromtarfile(cls, tarfile, *, dircheck=True):
++        """
++        See dircheck documentation in _frombuf().
++        """
+         buf = tarfile.fileobj.read(BLOCKSIZE)
+-        obj = cls.frombuf(buf, tarfile.encoding, tarfile.errors)
++        obj = cls._frombuf(buf, tarfile.encoding, tarfile.errors, dircheck=dircheck)
+         obj.offset = tarfile.fileobj.tell() - BLOCKSIZE
+         return obj._proc_member(tarfile)
+
+@@ -1336,7 +1357,7 @@ class TarInfo(object):
+
+         # Fetch the next header and process it.
+         try:
+-            next = self.fromtarfile(tarfile)
++            next = self._fromtarfile(tarfile, dircheck=False)
+         except HeaderError:
+             raise SubsequentHeaderError("missing or bad subsequent header")
+
+@@ -1466,7 +1487,7 @@ class TarInfo(object):
+
+         # Fetch the next header.
+         try:
+-            next = self.fromtarfile(tarfile)
++            next = self._fromtarfile(tarfile, dircheck=False)
+         except HeaderError:
+             raise SubsequentHeaderError("missing or bad subsequent header")
+
+diff --git a/Lib/test/test_tarfile.py b/Lib/test/test_tarfile.py
+index 9c89338..68ba73a 100644
+--- a/Lib/test/test_tarfile.py
++++ b/Lib/test/test_tarfile.py
+@@ -945,6 +945,25 @@ class LongnameTest:
+             self.assertEqual(tarinfo.type, self.longnametype)
+
+
++    def test_longname_file_not_directory(self):
++        # Test reading a longname file and ensure it is not handled as a directory
++        # Issue #141707
++        buf = io.BytesIO()
++        with tarfile.open(mode='w', fileobj=buf, format=self.format) as tar:
++            ti = tarfile.TarInfo()
++            ti.type = tarfile.AREGTYPE
++            ti.name = ('a' * 99) + '/' + ('b' * 3)
++            tar.addfile(ti)
++
++            expected = {t.name: t.type for t in tar.getmembers()}
++
++        buf.seek(0)
++        with tarfile.open(mode='r', fileobj=buf) as tar:
++            actual = {t.name: t.type for t in tar.getmembers()}
++
++        self.assertEqual(expected, actual)
++
++
+ class GNUReadTest(LongnameTest, ReadTest, unittest.TestCase):
+
+     subdir = "gnu"
+diff --git a/Misc/ACKS b/Misc/ACKS
+index ed9b639..0702556 100644
+--- a/Misc/ACKS
++++ b/Misc/ACKS
+@@ -1367,6 +1367,7 @@ Dhushyanth Ramasamy
+ Ashwin Ramaswami
+ Jeff Ramnani
+ Bayard Randel
++Eashwar Ranganathan
+ Varpu Rantala
+ Brodie Rao
+ Rémi Rampin
+diff --git a/Misc/NEWS.d/next/Library/2025-11-18-06-35-53.gh-issue-141707.DBmQIy.rst b/Misc/NEWS.d/next/Library/2025-11-18-06-35-53.gh-issue-141707.DBmQIy.rst
+new file mode 100644
+index 0000000..1f5b8ed
+--- /dev/null
++++ b/Misc/NEWS.d/next/Library/2025-11-18-06-35-53.gh-issue-141707.DBmQIy.rst
+@@ -0,0 +1,2 @@
++Don't change :class:`tarfile.TarInfo` type from ``AREGTYPE`` to ``DIRTYPE`` when parsing
++GNU long name or link headers.
+--
+2.55.0

--- a/meta-core/recipes-devtools/python/python3/CVE-2025-13462-0002.patch
+++ b/meta-core/recipes-devtools/python/python3/CVE-2025-13462-0002.patch
@@ -1,0 +1,38 @@
+From f4b7fd50b80e0d0e8c075104390c17f6573857e5 Mon Sep 17 00:00:00 2001
+From: Zach Malinowski <zach.malinowski@protonmail.com>
+Date: Thu, 27 Aug 2026 10:23:55 -0500
+
+This partial cherry pick of upstream to fit Python 3.8. This splits the debian patch into 2 parts.
+This is part 2.
+
+Co-authored-by: Chris Fernald <chrisf671@gmail.com>
+CVE: CVE-2025-13462
+Upstream-Status: Submitted [https://github.com/python/cpython/commit/46d0e1c06e063d0d239dcef60bcafadcfcf2eed1]
+Origin: Backport [https://salsa.debian.org/lts-team/packages/python3.9/-/blob/debian/bullseye/debian/patches/CVE-2025-13462.patch]
+Signed-off-by: Zach Malinowski <zach.malinowski@protonmail.com>
+---
+ Lib/test/test_tarfile.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Lib/test/test_tarfile.py b/Lib/test/test_tarfile.py
+index 68ba73a..b4d2842 100644
+--- a/Lib/test/test_tarfile.py
++++ b/Lib/test/test_tarfile.py
+@@ -968,6 +968,7 @@ class GNUReadTest(LongnameTest, ReadTest, unittest.TestCase):
+
+     subdir = "gnu"
+     longnametype = tarfile.GNUTYPE_LONGNAME
++    format = tarfile.GNU_FORMAT
+
+     # Since 3.2 tarfile is supposed to accurately restore sparse members and
+     # produce files with holes. This is what we actually want to test here.
+@@ -1027,6 +1028,7 @@ class PaxReadTest(LongnameTest, ReadTest, unittest.TestCase):
+
+     subdir = "pax"
+     longnametype = tarfile.XHDTYPE
++    format = tarfile.PAX_FORMAT
+
+     def test_pax_global_headers(self):
+         tar = tarfile.open(tarname, encoding="iso8859-1")
+--
+2.55.0

--- a/meta-core/recipes-devtools/python/python3_3.8.20.bb
+++ b/meta-core/recipes-devtools/python/python3_3.8.20.bb
@@ -55,6 +55,8 @@ SRC_URI_append = " \
     file://CVE-2024-9287.patch \
     file://CVE-2025-13836.patch \
     file://0001-test_concurrent_futures-skip-flaky-tests-for-3.8.patch \
+    file://CVE-2025-13462-0001.patch \
+    file://CVE-2025-13462-0002.patch \
 "
 
 SRC_URI[sha256sum] = "6fb89a7124201c61125c0ab4cf7f6894df339a40c02833bfd28ab4d7691fafb4"


### PR DESCRIPTION
Backport CVE-2025-13462 fix to python3. This fix is debian's
implementation of the fix for CVE-2025-13462. Debian's cherry pick is not an exact match to the backport to python 3.10. Additional corrections were made.

References:
https://security-tracker.debian.org/tracker/CVE-2025-13462
https://nvd.nist.gov/vuln/detail/CVE-2025-13462

CVE: CVE-2025-13462
Upstream-Status: Submitted [https://github.com/python/cpython/commit/72dde1016493c52abe857fc4a7bf6c40138b4114]
Origin: Backport [https://salsa.debian.org/lts-team/packages/python3.9/-/blob/debian/bullseye/debian/patches/CVE-2025-13462.patch]
Signed-off-by: Zach Malinowski [zach.malinowski@protonmail.com](mailto:zach.malinowski@protonmail.com)