### PR TITLE
jq: Fix CVE-2026-33948

### DIFF
--- a/meta-oe/recipes-devtools/jq/jq/CVE-2026-33948.patch
+++ b/meta-oe/recipes-devtools/jq/jq/CVE-2026-33948.patch
@@ -1,0 +1,52 @@
+From 743fc40cd056ded3bccf4a96d4f44bfe7f8585e6 Mon Sep 17 00:00:00 2001
+From: itchyny <itchyny@cybozu.co.jp>
+Date: Mon, 13 Apr 2026 08:46:11 +0900
+Subject: [PATCH] Fix NUL truncation in the JSON parser
+
+This fixes CVE-2026-33948.
+
+CVE: CVE-2026-33948
+Upstream-Status: Backport [https://github.com/jqlang/jq/commit/6374ae0bcdfe33a18eb0ae6db28493b1f34a0a5b]
+Signed-off-by: Zach Malinowski <zach.malinowski@protonmail.com>
+---
+ src/util.c   | 8 +-------
+ tests/shtest | 6 ++++++
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/util.c b/src/util.c
+index df83952..cd21a43 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -324,13 +324,7 @@ static int jq_util_input_read_more(jq_util_input_state *state) {
+       if (p != NULL)
+         state->current_line++;
+ 
+-      if (p == NULL && state->parser != NULL) {
+-        /*
+-         * There should be no NULs in JSON texts (but JSON text
+-         * sequences are another story).
+-         */
+-        state->buf_valid_len = strlen(state->buf);
+-      } else if (p == NULL && feof(state->current_input)) {
++      if (p == NULL && feof(state->current_input)) {
+         size_t i;
+ 
+         /*
+diff --git a/tests/shtest b/tests/shtest
+index 86fec33..804607f 100755
+--- a/tests/shtest
++++ b/tests/shtest
+@@ -306,4 +306,10 @@ JQ_COLORS="0123456789123:0123456789123:0123456789123:0123456789123:0123456789123
+ cmp $d/color $d/expect
+ cmp $d/warning $d/expect_warning
+ 
++# CVE-2026-33948: No NUL truncation in the JSON parser
++if printf '{}\x00{}' | $JQ >/dev/null 2> /dev/null; then
++  printf 'Error expected but jq exited successfully\n' 1>&2
++  exit 1
++fi
++
+ exit 0
+-- 
+2.55.0
+

--- a/meta-oe/recipes-devtools/jq/jq_1.6.bbappend
+++ b/meta-oe/recipes-devtools/jq/jq_1.6.bbappend
@@ -4,6 +4,7 @@ SRC_URI_append = " \
     file://CVE-2024-23337.patch \
     file://CVE-2025-48060.patch \
     file://CVE-2026-39979.patch \
+    file://CVE-2026-33948.patch \
     "
 
 # fixed-version: Does not affect jq 1.6.


### PR DESCRIPTION
Backport patch to fix CVE-2026-33948.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2026-33948

CVE: CVE-2026-33948
Upstream-Status: Backport [https://github.com/jqlang/jq/commit/6374ae0bcdfe33a18eb0ae6db28493b1f34a0a5b]