### PR TITLE
glib-2.0: fix CVE-2026-58015

### DIFF
--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p1.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p1.patch
@@ -1,0 +1,98 @@
+From 4e4aef6cdc8358bae108f0a5cf87ba8de087aafe Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Tue, 28 Apr 2026 15:47:30 +0100
+Subject: [PATCH] gdbusauthmechanismsha1: Validate cookie context
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Without validation, the server could send a malicious context which
+contains path traversal characters, allowing it to exfiltrate a SHA-1
+hashed copy of arbitrary data from the client’s file system.
+
+To exploit this successfully would require the client to choose to
+connect peer-to-peer to a malicious D-Bus server and to choose the SHA-1
+authentication mechanism in preference to all the other mechanisms. This
+is vanishingly unlikely.
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p1.patch?h=scarthgap
+
+CVE: CVE-2026-58015
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/db9c8fae398b0c457e660ce63dd5afec8993046a]
+
+Backport Changes:
+- Added <stdint.h> include because the target branch does not otherwise
+  expose uint8_t used by the upstream validation code during native builds.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Fixes: #3931
+(cherry picked from commit db9c8fae398b0c457e660ce63dd5afec8993046a)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ gio/gdbusauthmechanismsha1.c | 37 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 37 insertions(+)
+
+diff --git a/gio/gdbusauthmechanismsha1.c b/gio/gdbusauthmechanismsha1.c
+index ed5aa3f..d2755ba 100644
+--- a/gio/gdbusauthmechanismsha1.c
++++ b/gio/gdbusauthmechanismsha1.c
+@@ -20,6 +20,7 @@
+ 
+ #include "config.h"
+ 
++#include <stdint.h>
+ #include <string.h>
+ #include <fcntl.h>
+ #include <errno.h>
+@@ -1191,6 +1192,34 @@ mechanism_client_initiate (GDBusAuthMechanism   *mechanism,
+   return initial_response;
+ }
+ 
++/* Context names must be valid ASCII, nonzero length, and may not contain the
++ * characters slash ("/"), backslash ("\"), space (" "), newline ("\n"),
++ * carriage return ("\r"), tab ("\t"), or period (".").
++ *
++ * See https://dbus.freedesktop.org/doc/dbus-specification.html#auth-mechanisms-sha */
++static gboolean
++validate_cookie_context (const char *cookie_context)
++{
++  size_t i = 0;
++
++  g_return_val_if_fail (cookie_context != NULL, FALSE);
++
++  for (i = 0; cookie_context[i] != '\0'; i++)
++    {
++      if ((uint8_t) cookie_context[i] >= 128 ||
++          cookie_context[i] == '/' ||
++          cookie_context[i] == '\\' ||
++          cookie_context[i] == ' ' ||
++          cookie_context[i] == '\n' ||
++          cookie_context[i] == '\r' ||
++          cookie_context[i] == '\t' ||
++          cookie_context[i] == '.')
++        return FALSE;
++    }
++
++  return (i > 0);
++}
++
+ static void
+ mechanism_client_data_receive (GDBusAuthMechanism   *mechanism,
+                                const gchar          *data,
+@@ -1225,6 +1254,14 @@ mechanism_client_data_receive (GDBusAuthMechanism   *mechanism,
+     }
+ 
+   cookie_context = tokens[0];
++  if (!validate_cookie_context (tokens[0]))
++    {
++      g_free (m->priv->reject_reason);
++      m->priv->reject_reason = g_strdup_printf ("Malformed cookie_context '%s'", tokens[0]);
++      m->priv->state = G_DBUS_AUTH_MECHANISM_STATE_REJECTED;
++      goto out;
++    }
++
+   cookie_id = g_ascii_strtoll (tokens[1], &endp, 10);
+   if (*endp != '\0')
+     {

--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p2.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p2.patch
@@ -1,0 +1,55 @@
+From 3aaa04a07cc617092e76508949b1d493043090fd Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Tue, 28 Apr 2026 15:49:54 +0100
+Subject: [PATCH] gdbusauthmechanismsha1: Improve validation of cookie ID
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The D-Bus specification says the cookie ID has to be non-negative, but
+we weren’t checking that (or checking that it was non-empty).
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p2.patch?h=scarthgap
+
+CVE: CVE-2026-58015
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/c0531125344bb25fd66ffb7435ed6c285de09aeb]
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+(cherry picked from commit c0531125344bb25fd66ffb7435ed6c285de09aeb)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ gio/gdbusauthmechanismsha1.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gio/gdbusauthmechanismsha1.c b/gio/gdbusauthmechanismsha1.c
+index d2755ba..9f131a6 100644
+--- a/gio/gdbusauthmechanismsha1.c
++++ b/gio/gdbusauthmechanismsha1.c
+@@ -1228,7 +1228,7 @@ mechanism_client_data_receive (GDBusAuthMechanism   *mechanism,
+   GDBusAuthMechanismSha1 *m = G_DBUS_AUTH_MECHANISM_SHA1 (mechanism);
+   gchar **tokens;
+   const gchar *cookie_context;
+-  guint cookie_id;
++  int64_t cookie_id;
+   const gchar *server_challenge;
+   gchar *client_challenge;
+   gchar *endp;
+@@ -1263,7 +1263,7 @@ mechanism_client_data_receive (GDBusAuthMechanism   *mechanism,
+     }
+ 
+   cookie_id = g_ascii_strtoll (tokens[1], &endp, 10);
+-  if (*endp != '\0')
++  if (*endp != '\0' || endp == tokens[1] || cookie_id < 0 || cookie_id > UINT32_MAX)
+     {
+       g_free (m->priv->reject_reason);
+       m->priv->reject_reason = g_strdup_printf ("Malformed cookie_id '%s'", tokens[1]);
+@@ -1273,7 +1273,7 @@ mechanism_client_data_receive (GDBusAuthMechanism   *mechanism,
+   server_challenge = tokens[2];
+ 
+   error = NULL;
+-  cookie = keyring_lookup_entry (cookie_context, cookie_id, &error);
++  cookie = keyring_lookup_entry (cookie_context, (unsigned int) cookie_id, &error);
+   if (cookie == NULL)
+     {
+       g_free (m->priv->reject_reason);

--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p3.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p3.patch
@@ -1,0 +1,198 @@
+From ca16fdbd5a4656b8eafde5f61aa752e49cb326d9 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Tue, 28 Apr 2026 15:51:00 +0100
+Subject: [PATCH] gdbusauthmechanism: Expose client reject reason as a new
+ vfunc
+
+We can do this because `gdbusauthmechanism.h` is a private header.
+
+Hook it up to the existing `reject_reason` code in each
+`GDBusAuthMechanism` implementation, as all three implementations
+currently intermingle reject reasons from the server and client code, so
+there would currently be no benefit to having a separate server and
+client implementation of `*_get_reject_reason()`.
+
+This new private API will be used in a new unit test in the following
+commit.
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p3.patch?h=scarthgap
+
+CVE: CVE-2026-58015
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/060aea67de7517d531b8fe2cdc07aa1a00ddeb22]
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+(cherry picked from commit 060aea67de7517d531b8fe2cdc07aa1a00ddeb22)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ gio/gdbusauthmechanism.c         | 7 +++++++
+ gio/gdbusauthmechanism.h         | 2 ++
+ gio/gdbusauthmechanismanon.c     | 8 ++++----
+ gio/gdbusauthmechanismexternal.c | 8 ++++----
+ gio/gdbusauthmechanismsha1.c     | 8 ++++----
+ 5 files changed, 21 insertions(+), 12 deletions(-)
+
+diff --git a/gio/gdbusauthmechanism.c b/gio/gdbusauthmechanism.c
+index 897d414..6ed7fb5 100644
+--- a/gio/gdbusauthmechanism.c
++++ b/gio/gdbusauthmechanism.c
+@@ -324,6 +324,13 @@ _g_dbus_auth_mechanism_client_data_send (GDBusAuthMechanism *mechanism,
+   return G_DBUS_AUTH_MECHANISM_GET_CLASS (mechanism)->client_data_send (mechanism, out_data_len);
+ }
+ 
++gchar *
++_g_dbus_auth_mechanism_client_get_reject_reason (GDBusAuthMechanism *mechanism)
++{
++  g_return_val_if_fail (G_IS_DBUS_AUTH_MECHANISM (mechanism), NULL);
++  return G_DBUS_AUTH_MECHANISM_GET_CLASS (mechanism)->client_get_reject_reason (mechanism);
++}
++
+ void
+ _g_dbus_auth_mechanism_client_shutdown (GDBusAuthMechanism *mechanism)
+ {
+diff --git a/gio/gdbusauthmechanism.h b/gio/gdbusauthmechanism.h
+index cee87b0..5ab3e34 100644
+--- a/gio/gdbusauthmechanism.h
++++ b/gio/gdbusauthmechanism.h
+@@ -97,6 +97,7 @@ struct _GDBusAuthMechanismClass
+                                                          gsize                 data_len);
+   gchar                    *(*client_data_send)         (GDBusAuthMechanism   *mechanism,
+                                                          gsize                *out_data_len);
++  gchar                    *(*client_get_reject_reason) (GDBusAuthMechanism   *mechanism);
+   void                      (*client_shutdown)          (GDBusAuthMechanism   *mechanism);
+ };
+ 
+@@ -144,6 +145,7 @@ void                      _g_dbus_auth_mechanism_client_data_receive      (GDBus
+                                                                            gsize                 data_len);
+ gchar                    *_g_dbus_auth_mechanism_client_data_send         (GDBusAuthMechanism   *mechanism,
+                                                                           gsize                *out_data_len);
++gchar                    *_g_dbus_auth_mechanism_client_get_reject_reason (GDBusAuthMechanism   *mechanism);
+ void                      _g_dbus_auth_mechanism_client_shutdown          (GDBusAuthMechanism   *mechanism);
+ 
+ 
+diff --git a/gio/gdbusauthmechanismanon.c b/gio/gdbusauthmechanismanon.c
+index dd57826..ab947bb 100644
+--- a/gio/gdbusauthmechanismanon.c
++++ b/gio/gdbusauthmechanismanon.c
+@@ -54,7 +54,7 @@ static void                     mechanism_server_data_receive       (GDBusAuthMe
+                                                                      gsize                 data_len);
+ static gchar                   *mechanism_server_data_send          (GDBusAuthMechanism   *mechanism,
+                                                                      gsize                *out_data_len);
+-static gchar                   *mechanism_server_get_reject_reason  (GDBusAuthMechanism   *mechanism);
++static gchar                   *mechanism_server_or_client_get_reject_reason (GDBusAuthMechanism   *mechanism);
+ static void                     mechanism_server_shutdown           (GDBusAuthMechanism   *mechanism);
+ static GDBusAuthMechanismState  mechanism_client_get_state          (GDBusAuthMechanism   *mechanism);
+ static gchar                   *mechanism_client_initiate           (GDBusAuthMechanism   *mechanism,
+@@ -100,12 +100,13 @@ _g_dbus_auth_mechanism_anon_class_init (GDBusAuthMechanismAnonClass *klass)
+   mechanism_class->server_initiate           = mechanism_server_initiate;
+   mechanism_class->server_data_receive       = mechanism_server_data_receive;
+   mechanism_class->server_data_send          = mechanism_server_data_send;
+-  mechanism_class->server_get_reject_reason  = mechanism_server_get_reject_reason;
++  mechanism_class->server_get_reject_reason  = mechanism_server_or_client_get_reject_reason;
+   mechanism_class->server_shutdown           = mechanism_server_shutdown;
+   mechanism_class->client_get_state          = mechanism_client_get_state;
+   mechanism_class->client_initiate           = mechanism_client_initiate;
+   mechanism_class->client_data_receive       = mechanism_client_data_receive;
+   mechanism_class->client_data_send          = mechanism_client_data_send;
++  mechanism_class->client_get_reject_reason  = mechanism_server_or_client_get_reject_reason;
+   mechanism_class->client_shutdown           = mechanism_client_shutdown;
+ }
+ 
+@@ -219,12 +220,11 @@ mechanism_server_data_send (GDBusAuthMechanism   *mechanism,
+ }
+ 
+ static gchar *
+-mechanism_server_get_reject_reason (GDBusAuthMechanism   *mechanism)
++mechanism_server_or_client_get_reject_reason (GDBusAuthMechanism   *mechanism)
+ {
+   GDBusAuthMechanismAnon *m = G_DBUS_AUTH_MECHANISM_ANON (mechanism);
+ 
+   g_return_val_if_fail (G_IS_DBUS_AUTH_MECHANISM_ANON (mechanism), NULL);
+-  g_return_val_if_fail (m->priv->is_server && !m->priv->is_client, NULL);
+   g_return_val_if_fail (m->priv->state == G_DBUS_AUTH_MECHANISM_STATE_REJECTED, NULL);
+ 
+   /* can never end up here because we are never in the REJECTED state */
+diff --git a/gio/gdbusauthmechanismexternal.c b/gio/gdbusauthmechanismexternal.c
+index b3f2117..71d2f73 100644
+--- a/gio/gdbusauthmechanismexternal.c
++++ b/gio/gdbusauthmechanismexternal.c
+@@ -61,7 +61,7 @@ static void                     mechanism_server_data_receive       (GDBusAuthMe
+                                                                      gsize                 data_len);
+ static gchar                   *mechanism_server_data_send          (GDBusAuthMechanism   *mechanism,
+                                                                      gsize                *out_data_len);
+-static gchar                   *mechanism_server_get_reject_reason  (GDBusAuthMechanism   *mechanism);
++static gchar                   *mechanism_server_or_client_get_reject_reason (GDBusAuthMechanism   *mechanism);
+ static void                     mechanism_server_shutdown           (GDBusAuthMechanism   *mechanism);
+ static GDBusAuthMechanismState  mechanism_client_get_state          (GDBusAuthMechanism   *mechanism);
+ static gchar                   *mechanism_client_initiate           (GDBusAuthMechanism   *mechanism,
+@@ -107,12 +107,13 @@ _g_dbus_auth_mechanism_external_class_init (GDBusAuthMechanismExternalClass *kla
+   mechanism_class->server_initiate           = mechanism_server_initiate;
+   mechanism_class->server_data_receive       = mechanism_server_data_receive;
+   mechanism_class->server_data_send          = mechanism_server_data_send;
+-  mechanism_class->server_get_reject_reason  = mechanism_server_get_reject_reason;
++  mechanism_class->server_get_reject_reason  = mechanism_server_or_client_get_reject_reason;
+   mechanism_class->server_shutdown           = mechanism_server_shutdown;
+   mechanism_class->client_get_state          = mechanism_client_get_state;
+   mechanism_class->client_initiate           = mechanism_client_initiate;
+   mechanism_class->client_data_receive       = mechanism_client_data_receive;
+   mechanism_class->client_data_send          = mechanism_client_data_send;
++  mechanism_class->client_get_reject_reason  = mechanism_server_or_client_get_reject_reason;
+   mechanism_class->client_shutdown           = mechanism_client_shutdown;
+ }
+ 
+@@ -295,12 +296,11 @@ mechanism_server_data_send (GDBusAuthMechanism   *mechanism,
+ }
+ 
+ static gchar *
+-mechanism_server_get_reject_reason (GDBusAuthMechanism   *mechanism)
++mechanism_server_or_client_get_reject_reason (GDBusAuthMechanism   *mechanism)
+ {
+   GDBusAuthMechanismExternal *m = G_DBUS_AUTH_MECHANISM_EXTERNAL (mechanism);
+ 
+   g_return_val_if_fail (G_IS_DBUS_AUTH_MECHANISM_EXTERNAL (mechanism), NULL);
+-  g_return_val_if_fail (m->priv->is_server && !m->priv->is_client, NULL);
+   g_return_val_if_fail (m->priv->state == G_DBUS_AUTH_MECHANISM_STATE_REJECTED, NULL);
+ 
+   /* can never end up here because we are never in the REJECTED state */
+diff --git a/gio/gdbusauthmechanismsha1.c b/gio/gdbusauthmechanismsha1.c
+index 9f131a6..2a16379 100644
+--- a/gio/gdbusauthmechanismsha1.c
++++ b/gio/gdbusauthmechanismsha1.c
+@@ -114,7 +114,7 @@ static void                     mechanism_server_data_receive       (GDBusAuthMe
+                                                                      gsize                 data_len);
+ static gchar                   *mechanism_server_data_send          (GDBusAuthMechanism   *mechanism,
+                                                                      gsize                *out_data_len);
+-static gchar                   *mechanism_server_get_reject_reason  (GDBusAuthMechanism   *mechanism);
++static gchar                   *mechanism_server_or_client_get_reject_reason (GDBusAuthMechanism   *mechanism);
+ static void                     mechanism_server_shutdown           (GDBusAuthMechanism   *mechanism);
+ static GDBusAuthMechanismState  mechanism_client_get_state          (GDBusAuthMechanism   *mechanism);
+ static gchar                   *mechanism_client_initiate           (GDBusAuthMechanism   *mechanism,
+@@ -166,12 +166,13 @@ _g_dbus_auth_mechanism_sha1_class_init (GDBusAuthMechanismSha1Class *klass)
+   mechanism_class->server_initiate           = mechanism_server_initiate;
+   mechanism_class->server_data_receive       = mechanism_server_data_receive;
+   mechanism_class->server_data_send          = mechanism_server_data_send;
+-  mechanism_class->server_get_reject_reason  = mechanism_server_get_reject_reason;
++  mechanism_class->server_get_reject_reason  = mechanism_server_or_client_get_reject_reason;
+   mechanism_class->server_shutdown           = mechanism_server_shutdown;
+   mechanism_class->client_get_state          = mechanism_client_get_state;
+   mechanism_class->client_initiate           = mechanism_client_initiate;
+   mechanism_class->client_data_receive       = mechanism_client_data_receive;
+   mechanism_class->client_data_send          = mechanism_client_data_send;
++  mechanism_class->client_get_reject_reason  = mechanism_server_or_client_get_reject_reason;
+   mechanism_class->client_shutdown           = mechanism_client_shutdown;
+ }
+ 
+@@ -1123,12 +1124,11 @@ mechanism_server_data_send (GDBusAuthMechanism   *mechanism,
+ }
+ 
+ static gchar *
+-mechanism_server_get_reject_reason (GDBusAuthMechanism   *mechanism)
++mechanism_server_or_client_get_reject_reason (GDBusAuthMechanism *mechanism)
+ {
+   GDBusAuthMechanismSha1 *m = G_DBUS_AUTH_MECHANISM_SHA1 (mechanism);
+ 
+   g_return_val_if_fail (G_IS_DBUS_AUTH_MECHANISM_SHA1 (mechanism), NULL);
+-  g_return_val_if_fail (m->priv->is_server && !m->priv->is_client, NULL);
+   g_return_val_if_fail (m->priv->state == G_DBUS_AUTH_MECHANISM_STATE_REJECTED, NULL);
+ 
+   return g_strdup (m->priv->reject_reason);

--- a/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p4.patch
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p4.patch
@@ -1,0 +1,223 @@
+From 753db72f28896241fc1f1a58563689f2caf7e129 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Tue, 28 Apr 2026 15:52:53 +0100
+Subject: [PATCH] tests: Add a unit test for GDBusAuthMechanismSha1 cookie
+ context parsing
+
+This checks for regressions in the fixes from the previous few commits.
+
+Origin: other, https://git.openembedded.org/openembedded-core/tree/meta/recipes-core/glib-2.0/glib-2.0/CVE-2026-58015_p4.patch?h=scarthgap
+
+CVE: CVE-2026-58015
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/0919301962291a712067ee0c5d273cc392f33277]
+
+Backport Changes:
+- Replaced the literal U+1F600 test string with its UTF-8 byte escapes to
+  avoid the observed Patchwork mbox truncation. The test input is unchanged.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+Helps: #3931
+(cherry picked from commit 0919301962291a712067ee0c5d273cc392f33277)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+[slightly modified patch: glib-2.72.3 does not support GDBusConnectionFlags
+ in GDBusAuthMechanismClass::client_initiate used in dbus_auth_mechanism_client_initiate]
+Signed-off-by: Andrej Koehler <akhldev@proton.me>
+---
+ gio/tests/gdbus-auth-mechanism-sha1.c | 174 ++++++++++++++++++++++++++
+ gio/tests/meson.build                 |   1 +
+ 2 files changed, 175 insertions(+)
+ create mode 100644 gio/tests/gdbus-auth-mechanism-sha1.c
+
+diff --git a/gio/tests/gdbus-auth-mechanism-sha1.c b/gio/tests/gdbus-auth-mechanism-sha1.c
+new file mode 100644
+index 0000000..7c339b3
+--- /dev/null
++++ b/gio/tests/gdbus-auth-mechanism-sha1.c
+@@ -0,0 +1,174 @@
++/* GLib testing framework examples and tests
++ *
++ * Copyright (C) 2026 Philip Withnall
++ *
++ * SPDX-License-Identifier: LGPL-2.1-or-later
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General
++ * Public License along with this library; if not, see <http://www.gnu.org/licenses/>.
++ *
++ * Author: Philip Withnall <pwithnall@gnome.org>
++ */
++
++#include <locale.h>
++#include <gio/gio.h>
++
++#include <string.h>
++#include <unistd.h>
++
++#include "gdbus-tests.h"
++
++#ifdef G_OS_UNIX
++#include <gio/gunixconnection.h>
++#include <gio/gnetworkingprivate.h>
++#include <gio/gunixsocketaddress.h>
++#include <gio/gunixfdlist.h>
++#endif
++
++#define GIO_COMPILATION 1
++#include "gdbusauthmechanism.h"
++#include "gdbusauthmechanismsha1.h"
++
++/* Vfunc wrappers copied from gdbusauthmechanism.c as they are not public. */
++static gboolean
++dbus_auth_mechanism_is_supported (GDBusAuthMechanism *mechanism)
++{
++  return G_DBUS_AUTH_MECHANISM_GET_CLASS (mechanism)->is_supported (mechanism);
++}
++
++static GDBusAuthMechanismState
++dbus_auth_mechanism_client_get_state (GDBusAuthMechanism *mechanism)
++{
++  return G_DBUS_AUTH_MECHANISM_GET_CLASS (mechanism)->client_get_state (mechanism);
++}
++
++static gchar *
++dbus_auth_mechanism_client_initiate (GDBusAuthMechanism   *mechanism,
++                                     size_t               *out_initial_response_len)
++{
++  return G_DBUS_AUTH_MECHANISM_GET_CLASS (mechanism)->client_initiate (mechanism,
++                                                                       out_initial_response_len);
++}
++
++static void
++dbus_auth_mechanism_client_data_receive (GDBusAuthMechanism *mechanism,
++                                         const char         *data,
++                                         size_t              data_len)
++{
++  G_DBUS_AUTH_MECHANISM_GET_CLASS (mechanism)->client_data_receive (mechanism, data, data_len);
++}
++
++static char *
++dbus_auth_mechanism_client_get_reject_reason (GDBusAuthMechanism *mechanism)
++{
++  return G_DBUS_AUTH_MECHANISM_GET_CLASS (mechanism)->client_get_reject_reason (mechanism);
++}
++
++static void
++dbus_auth_mechanism_client_shutdown (GDBusAuthMechanism *mechanism)
++{
++  G_DBUS_AUTH_MECHANISM_GET_CLASS (mechanism)->client_shutdown (mechanism);
++}
++
++static void
++test_server_challenge_validation (void)
++{
++  const struct
++    {
++      const char *server_challenge;
++      const char *expected_reject_reason_prefix;
++    }
++  vectors[] = {
++    { "valid_context 123 456", "Problems looking up entry in keyring" },
++    { "invalid/context 123 456", "Malformed cookie_context" },
++    { "invalid.context 123 456", "Malformed cookie_context" },
++    { " 123 456", "Malformed cookie_context" },
++    { "\xF0\x9F\x98\x80" " 123 456", "Malformed cookie_context" },
++    { "invalid\ncontext 123 456", "Malformed cookie_context" },
++    { "invalid\rcontext 123 456", "Malformed cookie_context" },
++    { "invalid\tcontext 123 456", "Malformed cookie_context" },
++    { "invalid\\context 123 456", "Malformed cookie_context" },
++    { "valid_context  456", "Malformed cookie_id" },
++    { "valid_context 123notanumber 456", "Malformed cookie_id" },
++    { "valid_context -1 456", "Malformed cookie_id" },
++    { "valid_context 4294967296 456", "Malformed cookie_id" },
++    { "valid_context 123  ", "Malformed data" },
++    { "valid_context ", "Malformed data" },
++  };
++  GType mechanism_type;
++  GDBusConnection *connection = NULL;
++
++  g_test_summary ("Test that GDBusAuthMechanismSha1 rejects various malformed server data lines");
++
++  /* Briefly connect to the actual bus to ensure the GDBusAuth mechanisms are
++   * all registered. */
++  session_bus_up ();
++
++  connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, NULL);
++  g_assert_nonnull (connection);
++  g_clear_object (&connection);
++
++  session_bus_down ();
++
++  /* Check that we now have the type ID for GDBusAuthMechanismSha1 */
++  mechanism_type = g_type_from_name ("GDBusAuthMechanismSha1");
++  g_assert_cmpint (mechanism_type,  !=, 0);
++
++  for (size_t i = 0; i < G_N_ELEMENTS (vectors); i++)
++    {
++      GDBusAuthMechanism *mechanism = NULL;
++      char *data = NULL;
++      size_t data_len = 0;
++      char *reject_reason = NULL;
++
++      mechanism = g_object_new (mechanism_type, NULL);
++
++      if (!dbus_auth_mechanism_is_supported (mechanism))
++        {
++          g_test_skip ("Mechanism not supported");
++          g_clear_object (&mechanism);
++          return;
++        }
++
++      data = dbus_auth_mechanism_client_initiate (mechanism,
++                                                  &data_len);
++      g_free (data);
++
++      dbus_auth_mechanism_client_data_receive (mechanism, vectors[i].server_challenge, strlen (vectors[i].server_challenge));
++
++      g_assert_cmpint (dbus_auth_mechanism_client_get_state (mechanism), ==, G_DBUS_AUTH_MECHANISM_STATE_REJECTED);
++
++      reject_reason = dbus_auth_mechanism_client_get_reject_reason (mechanism);
++      g_assert_true (g_str_has_prefix (reject_reason, vectors[i].expected_reject_reason_prefix));
++      g_free (reject_reason);
++
++      dbus_auth_mechanism_client_shutdown (mechanism);
++
++      g_clear_object (&mechanism);
++    }
++}
++
++int
++main (int   argc,
++      char *argv[])
++{
++  setlocale (LC_ALL, "C");
++
++  g_test_init (&argc, &argv, G_TEST_OPTION_ISOLATE_DIRS, NULL);
++
++  g_test_dbus_unset ();
++
++  g_test_add_func ("/gdbus/auth-mechanism-sha1/server-challenge-validation", test_server_challenge_validation);
++
++  return g_test_run ();
++}
+\ No newline at end of file
+diff --git a/gio/tests/meson.build b/gio/tests/meson.build
+index c806362..4434743 100644
+--- a/gio/tests/meson.build
++++ b/gio/tests/meson.build
+@@ -326,6 +326,7 @@ if host_system != 'windows'
+         'suite' : ['slow'],
+       },
+       'gdbus-auth' : {'extra_sources' : extra_sources},
++      'gdbus-auth-mechanism-sha1': {'extra_sources' : extra_sources},
+       'gdbus-bz627724' : {'extra_sources' : extra_sources},
+       'gdbus-close-pending' : {'extra_sources' : extra_sources},
+       'gdbus-connection' : {'extra_sources' : extra_sources},

--- a/meta-core/recipes-core/glib-2.0/glib-2.0_2.72.3.bbappend
+++ b/meta-core/recipes-core/glib-2.0/glib-2.0_2.72.3.bbappend
@@ -8,4 +8,8 @@ SRC_URI:append = " \
     file://CVE-2026-58012.patch \
     file://CVE-2026-58013.patch \
     file://CVE-2026-58014.patch \
+    file://CVE-2026-58015_p1.patch \
+    file://CVE-2026-58015_p2.patch \
+    file://CVE-2026-58015_p3.patch \
+    file://CVE-2026-58015_p4.patch \
 "


### PR DESCRIPTION
Migrates the patch files from scarthgap:
https://git.openembedded.org/openembedded-core/commit/meta/recipes-core/glib-2.0?h=scarthgap&id=b6b82e3c1442b658bd4c1689e09792c9a3a96947

All patch files apply cleanly except for the tests patch. Slightly modified the patch to be compatible with glib-2.72.3

Verified running ptest: 

```
Running test: glib/gdbus-auth-mechanism-sha1.test
# GLib-DEBUG: g_set_user_dirs: Setting HOME to /tmp/test_gdbus-auth-mechanism-sha1_2FW7U3/gdbus/auth-mechanism-sha1/server-challenge-validation/.dirs/home
# GLib-DEBUG: g_set_user_dirs: Setting XDG_CACHE_HOME to /tmp/test_gdbus-auth-mechanism-sha1_2FW7U3/gdbus/auth-mechanism-sha1/server-challenge-validation/.dirs/cache
# GLib-DEBUG: g_set_user_dirs: Setting XDG_CONFIG_DIRS to /tmp/test_gdbus-auth-mechanism-sha1_2FW7U3/gdbus/auth-mechanism-sha1/server-challenge-validation/.dirs/system-config1:/tmp/test_gdbus-auth-mechanism-sha1_2FW7U3/gdbus/auth-mechanism-sha1/server-challenge-validation/.dirs/system-config2
# GLib-DEBUG: g_set_user_dirs: Setting XDG_CONFIG_HOME to /tmp/test_gdbus-auth-mechanism-sha1_2FW7U3/gdbus/auth-mechanism-sha1/server-challenge-validation/.dirs/config
# GLib-DEBUG: g_set_user_dirs: Setting XDG_DATA_DIRS to /tmp/test_gdbus-auth-mechanism-sha1_2FW7U3/gdbus/auth-mechanism-sha1/server-challenge-validation/.dirs/system-data1:/tmp/test_gdbus-auth-mechanism-sha1_2FW7U3/gdbus/auth-mechanism-sha1/server-challenge-validation/.dirs/system-data2
# GLib-DEBUG: g_set_user_dirs: Setting XDG_DATA_HOME to /tmp/test_gdbus-auth-mechanism-sha1_2FW7U3/gdbus/auth-mechanism-sha1/server-challenge-validation/.dirs/data
# GLib-DEBUG: g_set_user_dirs: Setting XDG_STATE_HOME to /tmp/test_gdbus-auth-mechanism-sha1_2FW7U3/gdbus/auth-mechanism-sha1/server-challenge-validation/.dirs/state
# GLib-DEBUG: g_set_user_dirs: Setting XDG_RUNTIME_DIR to /tmp/test_gdbus-auth-mechanism-sha1_2FW7U3/gdbus/auth-mechanism-sha1/server-challenge-validation/.dirs/runtime
PASS: glib/gdbus-auth-mechanism-sha1.test

...

SUMMARY: total=259; passed=258; skipped=1; failed=0; user=1268.7s; system=1214.9s; maxrss=179844
```